### PR TITLE
Updated Volume Meter

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -95,7 +95,7 @@ BOOL CALLBACK MonitorInfoEnumProc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprc
 const int controlPadding = 3;
 
 const int totalControlAreaWidth  = minClientWidth;
-const int totalControlAreaHeight = 167;//170;//
+const int totalControlAreaHeight = 171;//170;//
 
 void OBS::ResizeRenderFrame(bool bRedrawRenderFrame)
 {
@@ -192,7 +192,7 @@ void OBS::ResizeWindow(bool bRedrawRenderFrame)
     const int controlHeight = 22;
 
     const int volControlHeight = 32;
-    const int volMeterHeight = 6;
+    const int volMeterHeight = 10;
 
     const int textControlHeight = 16;
 
@@ -1049,8 +1049,8 @@ void STDCALL OBS::MuteDesktopHotkey(DWORD hotkey, UPARAM param, bool bDown)
 
 void OBS::UpdateAudioMeters()
 {
-    SetVolumeMeterValue(GetDlgItem(hwndMain, ID_DESKTOPVOLUMEMETER), desktopMag);
-    SetVolumeMeterValue(GetDlgItem(hwndMain, ID_MICVOLUMEMETER), micMag);
+    SetVolumeMeterValue(GetDlgItem(hwndMain, ID_DESKTOPVOLUMEMETER), desktopMag, desktopMax);
+    SetVolumeMeterValue(GetDlgItem(hwndMain, ID_MICVOLUMEMETER), micMag, micMax);
 }
 
 HICON OBS::GetIcon(HINSTANCE hInst, int resource)
@@ -1758,17 +1758,38 @@ void OBS::Stop()
     bTestStream = false;
 }
 
-inline float MultiplyAudioBuffer(float *buffer, int totalFloats, float mulVal)
+inline void MultiplyAudioBuffer(float *buffer, int totalFloats, float mulVal, float &RMS, float &MAX)
 {
     float sum = 0.0f;
-    
+    int totalFloatsStore = totalFloats;
+
+    float Max = 0.0f;
+
     if(App->SSE2Available() && (UPARAM(buffer) & 0xF) == 0)
     {
         UINT alignedFloats = totalFloats & 0xFFFFFFFC;
         __m128 sseMulVal = _mm_set_ps1(mulVal);
 
         for(UINT i=0; i<alignedFloats; i += 4)
-            _mm_store_ps(buffer+i, _mm_mul_ps(_mm_load_ps(buffer+i), sseMulVal));
+        {
+            __m128 sseScaledVals = _mm_mul_ps(_mm_load_ps(buffer+i), sseMulVal);
+            _mm_store_ps(buffer+i, sseScaledVals);
+            
+            /*compute squares and add them to the sum*/
+            __m128 sseSquares = _mm_mul_ps(sseScaledVals, sseScaledVals);
+            sum += sseSquares.m128_f32[0] + sseSquares.m128_f32[1] + sseSquares.m128_f32[2] + sseSquares.m128_f32[3];
+
+            /* 
+                sse maximum of squared floats 
+                concept from: http://stackoverflow.com/questions/9795529/how-to-find-the-horizontal-maximum-in-a-256-bit-avx-vector
+            */
+            __m128 sseSquaresP = _mm_shuffle_ps(sseSquares, sseSquares, _MM_SHUFFLE(1, 0, 3, 2));
+            __m128 halfmax = _mm_max_ps(sseSquares, sseSquaresP);
+            __m128 halfmaxP = _mm_shuffle_ps(halfmax, halfmax, _MM_SHUFFLE(0,1,2,3));
+            __m128 maxs = _mm_max_ps(halfmax, halfmaxP);
+
+            Max = max(Max, maxs.m128_f32[0]);
+        }
 
         buffer      += alignedFloats;
         totalFloats -= alignedFloats;
@@ -1778,12 +1799,11 @@ inline float MultiplyAudioBuffer(float *buffer, int totalFloats, float mulVal)
     {
         buffer[i] *= mulVal;
         sum += buffer[i] * buffer[i];
+        Max = max(Max, buffer[i] * buffer[i]);
     }
 
-    if (!totalFloats)
-        return 0.0f;
-
-    return sqrt(sum / totalFloats);
+    RMS = sqrt(sum / totalFloatsStore);
+    MAX = sqrt(Max);
 }
 
 inline bool IsFiniteNumber(float x) 
@@ -2498,7 +2518,11 @@ void OBS::MainAudioLoop()
 
     UINT curAudioFrame = 0;
 
+    micMax = desktopMax = VOL_MIN;
+
     UINT audioFramesSinceMeterUpdate = 0;
+    UINT audioFramesSinceMicMaxUpdate = 0;
+    UINT audioFramesSinceDesktopMaxUpdate = 0;
 
     while(TRUE)
     {
@@ -2534,29 +2558,51 @@ void OBS::MainAudioLoop()
 
             UINT totalFloats = desktopAudioFrames*2;
             
-            /*multiply samples by volume and compute RMS of samples*/
-            float desktopRMS, micRMS = 0;
-            desktopRMS = MultiplyAudioBuffer(desktopBuffer, totalFloats, desktopVol);
+            /*multiply samples by volume and compute RMS and max of samples*/
+            float desktopRMS = 0, micRMS = 0, desktopMx = 0, micMx = 0;
+            MultiplyAudioBuffer(desktopBuffer, totalFloats, desktopVol, desktopRMS, desktopMx);
             if(bMicEnabled)
-                micRMS = MultiplyAudioBuffer(micBuffer, totalFloats, curMicVol);
+                MultiplyAudioBuffer(micBuffer, totalFloats, curMicVol, micRMS, micMx);
             
-            /*convert RMS of samples to dB*/            
-            float desktopMagCurrentSample = toDB(desktopRMS);
-            float micMagCurrentSample = toDB(micRMS);
+            /*convert RMS and Max of samples to dB*/            
+            desktopRMS = toDB(desktopRMS);
+            micRMS = toDB(micRMS);
+            desktopMx = toDB(desktopMx);
+            micMx = toDB(micMx);
+
+            /* update max if sample max is greater or after 1 second */
+            if(micMx > micMax || audioFramesSinceMicMaxUpdate >= 44100)
+            {
+                micMax = micMx;
+                audioFramesSinceMicMaxUpdate = 0;
+            }
+            else 
+            {
+                audioFramesSinceMicMaxUpdate += desktopAudioFrames;
+            }
+
+            if(desktopMx > desktopMax || audioFramesSinceDesktopMaxUpdate >= 44100)
+            {
+                desktopMax = desktopMx;
+                audioFramesSinceDesktopMaxUpdate = 0;
+            }
+            else 
+            {
+                audioFramesSinceDesktopMaxUpdate += desktopAudioFrames;
+            }
 
             /*low pass the level sampling*/
-            float alpha = 0.05f;
-
-            desktopMag = alpha * desktopMagCurrentSample + desktopMag * (1.0f - alpha);
-            micMag = alpha * micMagCurrentSample + micMag * (1.0f - alpha);
+            float alpha = 0.3f;
+            desktopMag = alpha * desktopRMS + desktopMag * (1.0f - alpha);
+            micMag = alpha * micRMS + micMag * (1.0f - alpha);
 
             // instant feedback
             //desktopMag = desktopMagCurrentSample;
             //micMag = micMagCurrentSample;
 
-            /*update the meter about every 100ms*/
+            /*update the meter about every 50ms*/
             audioFramesSinceMeterUpdate += desktopAudioFrames;
-            if(audioFramesSinceMeterUpdate >= 4410)
+            if(audioFramesSinceMeterUpdate >= 2205)
             {
                 PostMessage(hwndMain, WM_COMMAND, MAKEWPARAM(ID_MICVOLUMEMETER, VOLN_METERED), 0);
                 audioFramesSinceMeterUpdate = 0;

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -463,6 +463,7 @@ class OBS
     HANDLE  hSoundThread, hSoundDataMutex, hRequestAudioEvent;
     float   desktopVol, micVol;
     float    desktopMag, micMag;
+    float   desktopMax, micMax;
     List<FrameAudio> pendingAudioFrames;
     bool    bForceMicMono;
     float   micBoost;

--- a/Source/VolumeMeter.h
+++ b/Source/VolumeMeter.h
@@ -22,9 +22,9 @@
 #define VOLUME_METER_CLASS TEXT("OBSVolumeMeter")
 
 void InitVolumeMeter();
-float SetVolumeMeterValue(HWND hwnd, float fValue);
+float SetVolumeMeterValue(HWND hwnd, float fValue, float fMax);
 
-#define VOL_MIN -72
-#define VOL_MAX 6
+#define VOL_MIN -96
+#define VOL_MAX 0
 
 #define VOLN_METERED  0x302


### PR DESCRIPTION
I updated the volume meter: changed to logarithmic scale, added 6dB graduations, adjusted to more frequent updates, and added a level maximum indicator.

Youtube video of it in action (there is loud audio so you may want to turn down the volume before watching....): 
http://youtu.be/27CGflIKEhc

I ammended the sse code to compute the correct sum of squares and maximums.

I would do a sanity check on my SSE max code. I am fairly certain that it does the right computation, but I am unsure if it is actually worth doing the sse horizontal maximum instead of just doing a bunch of max(a,b)'s (performance wise).

I looked a lot at that audio meter program that notr1ch linked. What that does is it graphs the current maximum at all times (it slowly diminishes after some delay). What my implementation is doing is showing the RMS or geometric average of the signal to get a average volume level reading. I added a maximum bar to indicate maximum sample levels so that you can see where that is in the meter. Choosing between these two options is a design choice, so I will go with what you guys are comfortable with.  
