### PR TITLE
Button to set resolution based on source window resolution

### DIFF
--- a/OBS.rc
+++ b/OBS.rc
@@ -211,9 +211,10 @@ BEGIN
     COMBOBOX        IDC_WINDOW,107,66,197,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "Sources.SoftwareCaptureSource.Refresh",IDC_REFRESH,310,65,62,14
     CONTROL         "Sources.SoftwareCaptureSource.InnerWindow",IDC_INNERWINDOW,
-                    "Button",BS_AUTORADIOBUTTON,106,83,266,10
+                    "Button",BS_AUTORADIOBUTTON,106,83,204,10
     CONTROL         "Sources.SoftwareCaptureSource.EntireWindow",IDC_OUTERWINDOW,
-                    "Button",BS_AUTORADIOBUTTON,106,95,266,10
+                    "Button",BS_AUTORADIOBUTTON,106,95,204,10
+    PUSHBUTTON      "Sources.SoftwareCaptureSource.SetResolution", IDC_SETRES, 310, 82, 62, 14
     CONTROL         "Sources.SoftwareCaptureSource.MouseCapture",IDC_CAPTUREMOUSE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,113,283,10
     CONTROL         "Sources.SoftwareCaptureSource.CaptureLayered",IDC_CAPTURELAYERED,

--- a/Source/DesktopImageSource.cpp
+++ b/Source/DesktopImageSource.cpp
@@ -670,6 +670,7 @@ void SetDesktopCaptureType(HWND hwnd, UINT type)
 
     EnableWindow(GetDlgItem(hwnd, IDC_WINDOW),      type == 1);
     EnableWindow(GetDlgItem(hwnd, IDC_REFRESH),     type == 1);
+    EnableWindow(GetDlgItem(hwnd, IDC_SETRES),      type == 1);
     EnableWindow(GetDlgItem(hwnd, IDC_OUTERWINDOW), type == 1);
     EnableWindow(GetDlgItem(hwnd, IDC_INNERWINDOW), type == 1);
 }
@@ -1468,7 +1469,18 @@ INT_PTR CALLBACK ConfigDesktopSourceProc(HWND hwnd, UINT message, WPARAM wParam,
                 case IDC_INNERWINDOW:
                     SelectTargetWindow(hwnd);
                     break;
+                case IDC_SETRES:
+                    {
+                        String strVal;
+                        strVal.SetLength(GetWindowTextLength(GetDlgItem(hwnd, IDC_SIZEX)));
+                        GetWindowText(GetDlgItem(hwnd, IDC_SIZEX), strVal, strVal.Length()+1);
+                        AppConfig->SetInt(TEXT("Video"), TEXT("BaseWidth"), strVal.ToInt());
 
+                        strVal.SetLength(GetWindowTextLength(GetDlgItem(hwnd, IDC_SIZEY)));
+                        GetWindowText(GetDlgItem(hwnd, IDC_SIZEY), strVal, strVal.Length()+1);
+                        AppConfig->SetInt(TEXT("Video"), TEXT("BaseHeight"), strVal.ToInt());
+                        break;
+                    }
                 case IDC_REFRESH:
                     {
                         ConfigDesktopSourceInfo *info = (ConfigDesktopSourceInfo*)GetWindowLongPtr(hwnd, DWLP_USER);

--- a/resource.h
+++ b/resource.h
@@ -209,6 +209,7 @@
 #define IDC_USECBR                      1133
 #define IDC_COMBO1                      1139
 #define IDC_DISABLECTSADJUST            1140
+#define IDC_SETRES                      1141
 #define IDA_SOURCE_MOVEUP               40018
 #define IDA_SOURCE_MOVEDOWN             40019
 #define IDA_SOURCE_MOVETOTOP            40020
@@ -241,7 +242,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        141
 #define _APS_NEXT_COMMAND_VALUE         40046
-#define _APS_NEXT_CONTROL_VALUE         1141
+#define _APS_NEXT_CONTROL_VALUE         1142
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/rundir/locale/en.txt
+++ b/rundir/locale/en.txt
@@ -214,6 +214,7 @@ Sources.SoftwareCaptureSource.RegionWindowText      "Press Enter, Esc, or click 
 Sources.SoftwareCaptureSource.Select                "Select"
 Sources.SoftwareCaptureSource.SelectRegion          "Select Region"
 Sources.SoftwareCaptureSource.SelectRegionTooltip   "When selecting a region, move by clicking and dragging, or resize the rectangle by clicking the edges."
+Sources.SoftwareCaptureSource.SetResolution         "Set Resolution"
 Sources.SoftwareCaptureSource.Similarity            "Similarity (1-100):"
 Sources.SoftwareCaptureSource.Size                  "Size:"
 Sources.SoftwareCaptureSource.SpillReduction        "Spill Reduction:"


### PR DESCRIPTION
I found myself changing the resolution a lot when streaming small windows, so I added a button to the source window to set the resolution to match the selected window.  This does not call ResizeWindow because the function is private (if you decide this button is worthwhile you can decide to make it public or what).

I also edited the .rc file by hand.  I don't usually do Windows stuff so I'm not sure if I should have done it some other way.
