### PR TITLE
One call to RemoveRange is enough.

### DIFF
--- a/OBSApi/AudioSource.cpp
+++ b/OBSApi/AudioSource.cpp
@@ -632,7 +632,6 @@ UINT AudioSource::QueryAudio(float curVolume)
                             lastUsedTimestamp += 10-adjustVal;
 
                         AudioSegment *newSegment = new AudioSegment(storageBuffer.Array(), 441*2, lastUsedTimestamp);
-                        storageBuffer.RemoveRange(0, (441*2));
                         AddAudioSegment(newSegment, curVolume*sourceVolume);
                         storageBuffer.RemoveRange(0, (441*2));
 


### PR DESCRIPTION
Removing it twice causes invalid range warnings and would lead to negative size lists?
