### PR TITLE
Profile switching, hide/show, exit added to the Notification Area icon

### DIFF
--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -328,6 +328,7 @@ enum
     ID_GLOBALSOURCES,
     ID_PLUGINS,
     ID_DASHBOARD,
+    ID_MINIMIZERESTORE,
 
     ID_SWITCHPROFILE,
 };
@@ -801,6 +802,7 @@ private:
 
     void CallHotkey(DWORD hotkeyID, bool bDown);
 
+    static void AddProfilesToMenu(HMENU menu);
     static void ResetProfileMenu();
 
     void SetStatusBarData();

--- a/rundir/locale/en.txt
+++ b/rundir/locale/en.txt
@@ -171,6 +171,8 @@ Settings.General.Language       "Language:"
 Settings.General.Profile        "Setting Profile:"
 Settings.General.Notification   "Notification Area Icon"
 Settings.General.NotificationMinimize    "Minimize to Notification Area"
+Settings.General.ShowObs        "Show OBS"
+Settings.General.HideObs        "Hide OBS"
 Settings.General.Restart        "Changing the language will require restarting OBS.\r\n\r\n..Though I suppose if you're changing the language you can't understand this"
 
 Settings.Publish.AutoReconnect          "Auto-Reconnect:"


### PR DESCRIPTION
This completes the possible improvements from #144.

Added a right-click menu with 3 parts to the Notification Area icon:

![tray1](https://f.cloud.github.com/assets/2565912/293368/4d80f4e8-935f-11e2-92a0-ad4fc82b9932.png)
#### Part 1

```
If Settings -> General -> Minimize to Notification Area is checked
    If minimized
        Topmost menu option is Show OBS
    Else if normal
        Topmost menu option is Hide OBS
```
#### Part 2

The list of profiles. I had to extract reusable code out of `OBS::ResetProfileMenu()` into a new function, `OBS::AddProfilesToMenu(HMENU)` for this part of the menu.
#### Part 3

ID_EXIT

I also disabled the Notification Area icon interactions when OBS is not topmost - for example when the "Settings..." dialog is open:
- both click and right click now set that modal dialog (be it "Settings...", or "Game Capture" or whatever) as foreground window.

Because I'm not treating directly clicks on this menu, just sending proper `WM_COMMAND`s around (to select the profiles), I also moved the code I introduced in #144 for showing and hiding the OBS window into `OBSProc()` -> `WM_COMMAND` -> `ID_MINIMIZERESTORE`. So now `OBS_NOTIFICATIONAREA` just relays messages, respectively builds and tracks and destroys a menu that relays messages.

Also fixed some whitespace so that `switch`es and `if`s are consitent with the rest of the project.
