### PR TITLE
Moved the code for adding / removing the Notification Area icon...

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1238,6 +1238,22 @@ void OBS::ReloadIniSettings()
     hotkey = AppConfig->GetInt(TEXT("Publish"), TEXT("StartStreamHotkey"));
     if(hotkey)
         startStreamHotkeyID = API->CreateHotkey(hotkey, OBS::StartStreamHotkey, NULL);
+
+    //-------------------------------------------
+    // Notification Area icon
+    bool showIcon = AppConfig->GetInt(TEXT("General"), TEXT("ShowNotificationAreaIcon"), 0) != 0;
+    bool minimizeToIcon = AppConfig->GetInt(TEXT("General"), TEXT("MinimizeToNotificationArea"), 0) != 0;
+    if (showIcon)
+    {
+        ShowNotificationAreaIcon();
+        if (minimizeToIcon && IsIconic(hwndMain))
+            ShowWindow(hwndMain, SW_HIDE);
+    }
+    else
+        HideNotificationAreaIcon();
+    if (!minimizeToIcon && !IsWindowVisible(hwndMain))
+        ShowWindow(hwndMain, SW_SHOW);
+
 }
 
 

--- a/Source/OBSCapture.cpp
+++ b/Source/OBSCapture.cpp
@@ -312,7 +312,6 @@ void OBS::Start()
     //-------------------------------------------------------------
 
     bRunning = true;
-    UpdateNotificationAreaIcon();
 
     if(sceneElement)
     {
@@ -485,7 +484,6 @@ void OBS::Stop()
     ReportStopStreamTrigger();
 
     bRunning = false;
-    UpdateNotificationAreaIcon();
     if(hMainThread)
     {
         OSTerminateThread(hMainThread, 20000);


### PR DESCRIPTION
directly into `OBS::ReloadIniSettings()`, its proper place. Fixes a bug that caused the OBS window remain hidden and unreachable, according to Issue #155.
