### PR TITLE
Added the following options to the Notification Area icon:

### DIFF
--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -2588,6 +2588,18 @@ LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
                         }
                         AddProfilesToMenu(hMenu);
                         AppendMenu(hMenu, MF_SEPARATOR, 0, 0);
+                        if (App->bRunning)
+                        {
+                            if (App->bTestStream)
+                                AppendMenu(hMenu, MF_STRING, ID_TESTSTREAM, Str("MainWindow.StopTest"));
+                            else
+                                AppendMenu(hMenu, MF_STRING, ID_STARTSTOP, Str("MainWindow.StopStream"));
+                        }
+                        else
+                            AppendMenu(hMenu, MF_STRING, ID_STARTSTOP, Str("MainWindow.StartStream"));
+                        if (!IsIconic(hwnd))
+                            AppendMenu(hMenu, MF_STRING | (App->bFullscreenMode ? MF_CHECKED : 0), ID_FULLSCREENMODE, Str("MainMenu.Settings.FullscreenMode"));
+                        AppendMenu(hMenu, MF_STRING | (App->bAlwaysOnTop ? MF_CHECKED : 0), ID_ALWAYSONTOP, Str("MainMenu.Settings.AlwaysOnTop"));
                         AppendMenu(hMenu, MF_STRING, ID_FILE_EXIT, Str("MainWindow.Exit"));
                     
                         SetForegroundWindow(hwnd);


### PR DESCRIPTION
- start/stop streaming
- full screen preview toggle (only when not iconic)
- always on top toggle

![tray2](https://f.cloud.github.com/assets/2565912/295270/5b4df35a-9472-11e2-9105-59f5391e5ebd.png)
