### PR TITLE
Do not check for updates if in portable mode | Alternative way to enable portable mode

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -37,6 +37,7 @@ HINSTANCE   hinstMain       = NULL;
 ConfigFile  *GlobalConfig   = NULL;
 ConfigFile  *AppConfig      = NULL;
 OBS         *App            = NULL;
+bool        bIsPortable     = false;
 TCHAR       lpAppPath[MAX_PATH];
 TCHAR       lpAppDataPath[MAX_PATH];
 
@@ -339,7 +340,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     LPWSTR *args = CommandLineToArgvW(GetCommandLineW(), &numArgs);
 
     bool bDisableMutex = false;
-    bool bIsPortable = false;
 
     for(int i=1; i<numArgs; i++)
     {
@@ -393,6 +393,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         GetCurrentDirectory(dirSize, strDirectory.Array());
 
         scpy(lpAppPath, strDirectory);
+
+        //if -portable isn't specified in command line check if there's a file named "obs_portable_mode" in current working dir, if so, obs goes into portable mode
+        if(!bIsPortable)
+        {
+            String strPMFileName = lpAppPath;
+            strPMFileName += TEXT("\\obs_portable_mode");
+            if(OSFileExists(strPMFileName))
+                bIsPortable = true;
+        }
 
         TSTR lpAllocator = NULL;
 

--- a/Source/Main.h
+++ b/Source/Main.h
@@ -68,6 +68,7 @@ extern HINSTANCE    hinstMain;
 extern ConfigFile   *GlobalConfig;
 extern ConfigFile   *AppConfig;
 extern OBS          *App;
+extern bool         bIsPortable;
 extern TCHAR        lpAppPath[MAX_PATH];
 extern TCHAR        lpAppDataPath[MAX_PATH];
 

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -637,7 +637,8 @@ OBS::OBS()
     currentTime.QuadPart /= 10000000;
     currentTime.QuadPart -= 13000000000;
 
-    if (currentTime.QuadPart - lastUpdateTime.QuadPart >= 3600)
+    //note - don't check for updates if obs is in portable mode (the updater makes assumptions that user data is in appdata [R1CH])
+    if (currentTime.QuadPart - lastUpdateTime.QuadPart >= 3600 && !bIsPortable)
     {
         GlobalConfig->SetInt(TEXT("General"), TEXT("LastUpdateCheck"), (int)currentTime.QuadPart);
         OSCloseThread(OSCreateThread((XTHREAD)CheckUpdateThread, NULL));


### PR DESCRIPTION
Check if a file named "obs_portable_mode" exists in obs's working dir, if so, enable portable mode.
