### PR TITLE
fixed the header declaration for OBS::EnsureCropValid; the main window n...

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -268,7 +268,7 @@ OBS::OBS()
 
     bFullscreenMode = false;
 
-    hwndMain = CreateWindowEx(WS_EX_CONTROLPARENT|WS_EX_WINDOWEDGE, OBS_WINDOW_CLASS, OBS_VERSION_STRING,
+    hwndMain = CreateWindowEx(WS_EX_CONTROLPARENT|WS_EX_WINDOWEDGE, OBS_WINDOW_CLASS, GetApplicationName(),
         WS_OVERLAPPED | WS_THICKFRAME | WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_CAPTION | WS_SYSMENU | WS_CLIPCHILDREN,
         x, y, cx, cy, NULL, NULL, hinstMain, NULL);
     if(!hwndMain)
@@ -1623,16 +1623,15 @@ BOOL OBS::ShowNotificationAreaIcon()
 {
     BOOL result = FALSE;
     int idIcon = (bRunning && !bTestStream) ? IDI_ICON2 : IDI_ICON1;
-    String tooltip(TEXT("OBS"));
 
     if (!bNotificationAreaIcon)
     {
         bNotificationAreaIcon = true;
-        result = SetNotificationAreaIcon(NIM_ADD, idIcon, tooltip);
+        result = SetNotificationAreaIcon(NIM_ADD, idIcon, GetApplicationName());
     }
     else
     {
-        result = SetNotificationAreaIcon(NIM_MODIFY, idIcon, tooltip);
+        result = SetNotificationAreaIcon(NIM_MODIFY, idIcon, GetApplicationName());
     }
     return result;
 }

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -812,7 +812,7 @@ private:
     static Vect2 GetFrameToWindowScale();
 
     // helper to valid crops as you scale items
-    static bool EnsureCropValid(SceneItem *&item, Vect2 &minSize, Vect2 &snapSize, bool bControlDown, int cropEdges, bool cropSymmetric);
+    static bool EnsureCropValid(SceneItem *&scaleItem, Vect2 &minSize, Vect2 &snapSize, bool bControlDown, int cropEdges, bool cropSymmetric);
 
     static INT_PTR CALLBACK EnterGlobalSourceNameDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
     static INT_PTR CALLBACK EnterSourceNameDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
@@ -847,6 +847,9 @@ private:
 
     static void AddProfilesToMenu(HMENU menu);
     static void ResetProfileMenu();
+
+    static String GetApplicationName();
+    static void ResetApplicationName();
 
     void SetStatusBarData();
 

--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -2254,6 +2254,22 @@ void OBS::ResetProfileMenu()
 
 //----------------------------
 
+String OBS::GetApplicationName()
+{
+    String name;
+    name << App->GetCurrentProfile() << TEXT(" - ") << OBS_VERSION_STRING;
+    return name;
+}
+
+//----------------------------
+
+void OBS::ResetApplicationName()
+{
+    SetWindowText(hwndMain, GetApplicationName());
+}
+
+//----------------------------
+
 LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch(message)
@@ -2540,6 +2556,7 @@ LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
                                 GlobalConfig->SetString(TEXT("General"), TEXT("Profile"), strProfile);
                                 App->ReloadIniSettings();
                                 ResetProfileMenu();
+                                ResetApplicationName();
                             }
                         }
                     }


### PR DESCRIPTION
The main window now shows the current profile as requested per #223 

![title](https://f.cloud.github.com/assets/2565912/831508/dfcef9a8-f1ec-11e2-8d71-40e62c7396dd.png)

Same goes for the notification area icon tooltip

![narea](https://f.cloud.github.com/assets/2565912/831509/eb3652dc-f1ec-11e2-9090-c695ed02c977.png)
