### PR TITLE
Correctly show/hide the dashboard button upon profile change

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1104,15 +1104,10 @@ void OBS::ResizeWindow(bool bRedrawRenderFrame)
 
     xPos = resetXPos;
 
-    BOOL bStreamOutput = AppConfig->GetInt(TEXT("Publish"), TEXT("Mode")) == 0;
-
-    strDashboard = AppConfig->GetString(TEXT("Publish"), TEXT("Dashboard"));
-    BOOL bShowDashboardButton = strDashboard.IsValid() && bStreamOutput;
-
     SetWindowPos(GetDlgItem(hwndMain, ID_DASHBOARD), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
 
-    ShowWindow(GetDlgItem(hwndMain, ID_DASHBOARD), bShowDashboardButton ? SW_SHOW : SW_HIDE);
+    UpdateDashboardButton();
 
     SetWindowPos(GetDlgItem(hwndMain, ID_EXIT), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
@@ -1222,6 +1217,7 @@ void OBS::ReloadIniSettings()
     // dashboard
     strDashboard = AppConfig->GetString(TEXT("Publish"), TEXT("Dashboard"));
     strDashboard.KillSpaces();
+    UpdateDashboardButton();
 
     //-------------------------------------------
     // hotkeys
@@ -1647,4 +1643,15 @@ BOOL OBS::HideNotificationAreaIcon()
 {
     bNotificationAreaIcon = false;
     return SetNotificationAreaIcon(NIM_DELETE, 0, TEXT(""));
+}
+
+BOOL OBS::UpdateDashboardButton()
+{
+    //Are we in live stream mode, and do we have a non-empty dashboard string?
+    BOOL bStreamOutput = AppConfig->GetInt(TEXT("Publish"), TEXT("Mode")) == 0;
+    BOOL bDashboardValid = strDashboard.IsValid();
+
+    BOOL bShowDashboardButton = bPanelVisible && bStreamOutput && bDashboardValid;
+
+    return ShowWindow(GetDlgItem(hwndMain, ID_DASHBOARD), bShowDashboardButton ? SW_SHOW : SW_HIDE);
 }

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -993,6 +993,8 @@ public:
     BOOL ShowNotificationAreaIcon();
     BOOL UpdateNotificationAreaIcon();
     BOOL HideNotificationAreaIcon();
+
+    BOOL UpdateDashboardButton();
 };
 
 LONG CALLBACK OBSExceptionHandler (PEXCEPTION_POINTERS exceptionInfo);


### PR DESCRIPTION
Previously, switching profiles via the menu wouldn't show or hide the dashboard button (e.g. switching from a stream profile to a file output only profile would still show it).

ResizeWindow() still updates the visibility of the button since there's a few places that call it (hackily) to fix the dashboard button. I'm not confident in removing those since I'm not yet 100% sure that's the only reason they make that call (though one is actually commented, IIRC).
