### PR TITLE
added Open Log Folder to the start menu in the NSIS installer script

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -175,6 +175,7 @@ Section "Open Broadcaster Software" Section1
 	CreateShortCut "$DESKTOP\Open Broadcaster Software.lnk" "$INSTDIR\OBS.exe"
 	CreateDirectory "$SMPROGRAMS\Open Broadcaster Software"
 	CreateShortCut "$SMPROGRAMS\Open Broadcaster Software\Open Broadcaster Software (32bit).lnk" "$INSTDIR\OBS.exe"
+	CreateShortCut "$SMPROGRAMS\Open Broadcaster Software\Open Log Folder.lnk" "%AppData%\OBS\logs"
 	CreateShortCut "$SMPROGRAMS\Open Broadcaster Software\Uninstall.lnk" "$INSTDIR\uninstall.exe"
 
 	${if} ${RunningX64}
@@ -211,6 +212,7 @@ Section Uninstall
 	; Delete Shortcuts
 	Delete "$DESKTOP\Open Broadcaster Software.lnk"
 	Delete "$SMPROGRAMS\Open Broadcaster Software\Open Broadcaster Software (32bit).lnk"
+	Delete "$SMPROGRAMS\Open Broadcaster Software\Open Log Folder.lnk"
 	Delete "$SMPROGRAMS\Open Broadcaster Software\Uninstall.lnk"
 	${if} ${RunningX64}
 		Delete "$SMPROGRAMS\Open Broadcaster Software\Open Broadcaster Software (64bit).lnk"


### PR DESCRIPTION
https://obsproject.com/forum/viewtopic.php?f=7&t=97 mentions that you
can open the log folder within the start menu. This shortcut is included
but only in the Inno Setup not the NSIS setup. So I included it.
