### PR TITLE
changed recommended twitch bitrate from 4000 to 3500

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -21,7 +21,7 @@ services : {
     recommended : {
       "keyint"      : 2000
       "ratecontrol" : "cbr"
-      "max bitrate" : 4000
+      "max bitrate" : 3500
       "max audio bitrate" : 160
     }
   }


### PR DESCRIPTION
According to Cyrus Hall twitch doesn't support 4000 Kbps or up officially.

"We do not officially support streams at 5Mbps (or 4 Mbps for that matter)."

http://blog.twitch.tv/2013/08/new-minimum-broadcasting-requirements-coming-soon/#comment-1001835044
