### PR TITLE
Add API calls for capture fps, bytes per second, total frames, total frames dropped and total stream time.

### DIFF
--- a/OBSApi/APIDefs.cpp
+++ b/OBSApi/APIDefs.cpp
@@ -86,6 +86,9 @@ void OBSGetRenderFrameControlSize(UINT &width, UINT &height)    {API->GetRenderF
 void OBSGetOutputSize(UINT &width, UINT &height)                {API->GetOutputSize(width, height);}
 UINT OBSGetMaxFPS()                                             {return API->GetMaxFPS();}
 bool OBSGetRenderFrameIn1To1Mode()                              {return API->GetRenderFrameIn1To1Mode();}
+UINT OBSGetCaptureFPS()                                         {return API->GetCaptureFPS();}
+UINT OBSGetTotalFrames()                                        {return API->GetTotalFrames();}
+UINT OBSGetFramesDropped()                                      {return API->GetFramesDropped();}
 
 CTSTR OBSGetLanguage()          {return API->GetLanguage();}
 
@@ -98,6 +101,9 @@ UINT OBSAddStreamInfo(CTSTR lpInfo, StreamInfoPriority priority)            {ret
 void OBSSetStreamInfo(UINT infoID, CTSTR lpInfo)                            {API->SetStreamInfo(infoID, lpInfo);}
 void OBSSetStreamInfoPriority(UINT infoID, StreamInfoPriority priority)     {API->SetStreamInfoPriority(infoID, priority);}
 void OBSRemoveStreamInfo(UINT infoID)                                       {API->RemoveStreamInfo(infoID);}
+
+UINT OBSGetTotalStreamTime()    {return API->GetTotalStreamTime();}
+UINT OBSGetBytesPerSec()        {return API->GetBytesPerSec();}
 
 bool OBSUseMultithreadedOptimizations()         {return API->UseMultithreadedOptimizations();}
 

--- a/OBSApi/APIInterface.h
+++ b/OBSApi/APIInterface.h
@@ -181,6 +181,12 @@ public:
     virtual bool GetRecording() const = 0;
 
     virtual bool GetKeepRecording() const = 0;
+    
+    virtual UINT GetCaptureFPS() const=0;
+    virtual UINT GetTotalFrames() const=0;
+    virtual UINT GetFramesDropped() const=0;
+    virtual UINT GetTotalStreamTime() const=0;
+    virtual UINT GetBytesPerSec() const=0;
 };
 
 BASE_EXPORT extern APIInterface *API;
@@ -221,6 +227,9 @@ BASE_EXPORT void OBSGetRenderFrameControlSize(UINT &width, UINT &height);
 BASE_EXPORT void OBSGetOutputSize(UINT &width, UINT &height);
 BASE_EXPORT UINT OBSGetMaxFPS();
 BASE_EXPORT bool OBSGetIn1To1Mode();
+BASE_EXPORT UINT OBSGetCaptureFPS();
+BASE_EXPORT UINT OBSGetTotalFrames();
+BASE_EXPORT UINT OBSGetFramesDropped();
 
 BASE_EXPORT CTSTR OBSGetLanguage();
 
@@ -233,6 +242,9 @@ BASE_EXPORT UINT OBSAddStreamInfo(CTSTR lpInfo, StreamInfoPriority priority);
 BASE_EXPORT void OBSSetStreamInfo(UINT infoID, CTSTR lpInfo);
 BASE_EXPORT void OBSSetStreamInfoPriority(UINT infoID, StreamInfoPriority priority);
 BASE_EXPORT void OBSRemoveStreamInfo(UINT infoID);
+
+BASE_EXPORT UINT OBSGetTotalStreamTime();
+BASE_EXPORT UINT OBSGetBytesPerSec();
 
 BASE_EXPORT bool OBSUseMultithreadedOptimizations();
 

--- a/Source/API.cpp
+++ b/Source/API.cpp
@@ -607,6 +607,12 @@ public:
     virtual void RemoveSettingsPane(SettingsPane *pane) {App->RemoveSettingsPane(pane);}
 
     virtual UINT GetSampleRateHz() const {return App->GetSampleRateHz();}
+    
+    virtual UINT GetCaptureFPS() const        {return App->captureFPS;}
+    virtual UINT GetTotalFrames() const       {return App->network ? App->network->NumTotalVideoFrames() : 0;}
+    virtual UINT GetFramesDropped() const     {return App->curFramesDropped;}
+    virtual UINT GetTotalStreamTime() const   {return App->totalStreamTime;}
+    virtual UINT GetBytesPerSec() const       {return App->bytesPerSec;}
 };
 
 APIInterface* CreateOBSApiInterface()


### PR DESCRIPTION
I've been trying to find a way to get this information out of OBS and into a plugin. From what I understand the only way to do it is to edit the API. I added API calls to get the information from the status bar. This meant adding to API.cpp, APIDefs.cpp and APIInterface.h.

Thanks, Sloth
