### PR TITLE
Broadcast stream URL and Path via Web API

### DIFF
--- a/OBSApi/Utility/XConfig.cpp
+++ b/OBSApi/Utility/XConfig.cpp
@@ -749,7 +749,7 @@ String XConfig::ProcessString(TSTR &lpTemp)
         return String();
 
     String stringOut = string.Mid(1, string.Length()-1);
-    if (stringOut.IsEmpty())
+    if(stringOut.IsEmpty())
         return String();
 
     TSTR lpStringOut = stringOut;
@@ -798,7 +798,12 @@ bool  XConfig::ReadFileData(XElement *curElement, int level, TSTR &lpTemp)
             String strName;
 
             if(*lpTemp == '"')
+            {
                 strName = ProcessString(lpTemp);
+
+                // Previous character should have been a " by definition 
+                assert(strName[strName.Length()-1] != '\"');
+            }
             else
             {
                 TSTR lpDataStart = lpTemp;
@@ -844,16 +849,31 @@ bool  XConfig::ReadFileData(XElement *curElement, int level, TSTR &lpTemp)
                 String data;
 
                 if(*lpTemp == '"')
+                {
                     data = ProcessString(lpTemp);
+
+                    // Back one if we've hit a brace. 
+                    // This should back us onto a " by definition.
+                    if(lpTemp[0] == '}')
+                    {
+                        --lpTemp;
+                    }
+                }
                 else
                 {
                     TSTR lpDataStart = lpTemp;
 
-                    lpTemp = schr(lpTemp, '\n');
+                    TCHAR separators[] = {'\n', '}'};
+
+                    lpTemp = schr_n(lpTemp, separators, 2);
+
                     if(!lpTemp)
                         return false;
 
-                    if(lpTemp[-1] == '\r') --lpTemp;
+                    if (lpTemp[-1] == '\r')
+                    {
+                        --lpTemp;
+                    }
 
                     if(lpTemp != lpDataStart)
                     {
@@ -864,11 +884,23 @@ bool  XConfig::ReadFileData(XElement *curElement, int level, TSTR &lpTemp)
 
                         data.KillSpaces();
                     }
+
+                    if (lpTemp[0] == '}')
+                    {
+                        --lpTemp;
+                    }
                 }
 
-                lpTemp = schr(lpTemp, '\n');
+                TCHAR separators[] = {'\n', ',', '}'};
+
+                lpTemp = schr_n(lpTemp, separators, 3);
                 if(!lpTemp && curElement != RootElement)
                     return false;
+
+                if ((lpTemp[-1] == ',') || (lpTemp[0] == '}'))
+                {
+                    --lpTemp;
+                }
 
                 curElement->SubItems << new XDataItem(strName, data);
             }
@@ -980,6 +1012,27 @@ void  XConfig::WriteFileData(XFile &file, int indent, XElement *curElement)
     }
 }
 
+// Basically the same as Open (and in fact Open could/should call ParseString to do its thing)
+// But ParseString allows chunks of JSON type strings to be parse into the XConfig structure.
+bool  XConfig::ParseString(const String& config)
+{
+    String safe_copy = config;
+    TSTR lpTemp = safe_copy;
+
+    RootElement = new XElement(this, NULL, TEXT("Root"));
+
+    if(!ReadFileData(RootElement, 0, lpTemp))
+    {
+        for(DWORD i=0; i<RootElement->SubItems.Num(); i++)
+            delete RootElement->SubItems[i];
+
+        CrashError(TEXT("Error parsing X string '%s'"), config.Array());
+
+        Close(false);
+    }
+
+    return true;
+}
 
 bool  XConfig::Open(CTSTR lpFile)
 {

--- a/OBSApi/Utility/XConfig.h
+++ b/OBSApi/Utility/XConfig.h
@@ -226,6 +226,7 @@ public:
     inline ~XConfig() {Close();}
 
     bool    Open(CTSTR lpFile);
+    bool    ParseString(const String& config);
     void    Close(bool bSave=false);
     void    Save();
 

--- a/OBSApi/Utility/XString.cpp
+++ b/OBSApi/Utility/XString.cpp
@@ -1574,6 +1574,34 @@ TCHAR *STDCALL schr(const TCHAR *strSrc, const TCHAR chr)
     return (TCHAR*)strSrc;
 }
 
+// Checks if the given character is in the list
+static int IsCharInList(const TCHAR chr, const TCHAR chrList[], int chrListCount)
+{
+    int i = 0;
+
+    while (i<chrListCount && chr != chrList[i])
+    {
+        i++;
+    }
+
+    return i != chrListCount;
+}
+
+// A version of schr which can check against a list.
+TCHAR *STDCALL schr_n(const TCHAR *strSrc, const TCHAR chrList[], unsigned int chrListCount)
+{
+    if(!strSrc) return NULL;
+
+    // Set along until we hit something in our list
+    while (!IsCharInList(*strSrc, chrList, chrListCount))
+    {
+        if(*strSrc++ == 0)
+            return NULL;
+    }
+
+    return (TCHAR*)strSrc;
+}
+
 TCHAR *STDCALL sstr(const TCHAR *strSrc, const TCHAR *strSearch)
 {
     if(!strSearch || !strSrc) return NULL;

--- a/OBSApi/Utility/XString.h
+++ b/OBSApi/Utility/XString.h
@@ -34,6 +34,7 @@ BASE_EXPORT int    STDCALL   scmp_n(const TCHAR *str1, const TCHAR *str2, unsign
 BASE_EXPORT int    STDCALL   scmpi_n(const TCHAR *str1, const TCHAR *str2, unsigned int num);
 BASE_EXPORT TCHAR* STDCALL   srchr(const TCHAR *strSrc, TCHAR chr);
 BASE_EXPORT TCHAR* STDCALL   schr(const TCHAR *strSrc, TCHAR chr);
+BASE_EXPORT TCHAR* STDCALL   schr_n(const TCHAR *strSrc, const TCHAR chr[], unsigned int num);
 BASE_EXPORT TCHAR* STDCALL   sstr(const TCHAR *strSrc, const TCHAR *strSearch);
 BASE_EXPORT TCHAR* STDCALL   srchri(const TCHAR *strSrc, TCHAR chr);
 BASE_EXPORT TCHAR* STDCALL   schri(const TCHAR *strSrc, TCHAR chr);

--- a/Source/HTTPClient.cpp
+++ b/Source/HTTPClient.cpp
@@ -130,6 +130,111 @@ failure:
     return ret;
 }
 
+String HTTPGetString (CTSTR url, CTSTR extraHeaders, int *responseCode)
+{
+    HINTERNET hSession = NULL;
+    HINTERNET hConnect = NULL;
+    HINTERNET hRequest = NULL;
+    URL_COMPONENTS  urlComponents;
+    BOOL secure = FALSE;
+	String result = "";
+
+    String hostName, path;
+
+    const TCHAR *acceptTypes[] = {
+        TEXT("*/*"),
+        NULL
+    };
+
+    hostName.SetLength(256);
+    path.SetLength(1024);
+
+    zero(&urlComponents, sizeof(urlComponents));
+
+    urlComponents.dwStructSize = sizeof(urlComponents);
+    
+    urlComponents.lpszHostName = hostName;
+    urlComponents.dwHostNameLength = hostName.Length();
+
+    urlComponents.lpszUrlPath = path;
+    urlComponents.dwUrlPathLength = path.Length();
+
+    WinHttpCrackUrl(url, 0, 0, &urlComponents);
+
+    if (urlComponents.nPort == 443)
+        secure = TRUE;
+
+    hSession = WinHttpOpen(OBS_VERSION_STRING, WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession)
+        goto failure;
+
+    hConnect = WinHttpConnect(hSession, hostName, secure ? INTERNET_DEFAULT_HTTPS_PORT : INTERNET_DEFAULT_HTTP_PORT, 0);
+    if (!hConnect)
+        goto failure;
+
+    hRequest = WinHttpOpenRequest(hConnect, TEXT("GET"), path, NULL, WINHTTP_NO_REFERER, acceptTypes, secure ? WINHTTP_FLAG_SECURE|WINHTTP_FLAG_REFRESH : WINHTTP_FLAG_REFRESH);
+    if (!hRequest)
+        goto failure;
+
+    BOOL bResults = WinHttpSendRequest(hRequest, extraHeaders, extraHeaders ? -1 : 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+
+    // End the request.
+    if (bResults)
+        bResults = WinHttpReceiveResponse(hRequest, NULL);
+    else
+        goto failure;
+
+    TCHAR statusCode[8];
+    DWORD statusCodeLen;
+
+    statusCodeLen = sizeof(statusCode);
+    if (!WinHttpQueryHeaders (hRequest, WINHTTP_QUERY_STATUS_CODE, WINHTTP_HEADER_NAME_BY_INDEX, &statusCode, &statusCodeLen, WINHTTP_NO_HEADER_INDEX))
+        goto failure;
+
+    *responseCode = wcstoul(statusCode, NULL, 10);	
+
+    if (bResults && *responseCode == 200)
+    {
+        CHAR buffer[16384];
+        DWORD dwSize, dwOutSize;
+
+        do 
+        {
+            // Check for available data.
+            dwSize = 0;
+            if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
+                goto failure;
+
+            if (!WinHttpReadData(hRequest, (LPVOID)buffer, dwSize, &dwOutSize))
+            {
+                goto failure;
+            }
+            else
+            {
+                if (!dwOutSize)
+                    break;
+
+				// Ensure the string is terminated.
+				buffer[dwOutSize] = 0;
+
+				String b = String((LPCSTR)buffer);
+				result.AppendString(b);
+            }
+        } while (dwSize > 0);
+    }
+
+failure:
+    if (hSession)
+        WinHttpCloseHandle(hSession);
+    if (hConnect)
+        WinHttpCloseHandle(hConnect);
+    if (hRequest)
+        WinHttpCloseHandle(hRequest);
+
+    return result;
+}
+
+
 String CreateHTTPURL(String host, String path, String extra, bool secure)
 {
     URL_COMPONENTS components = {

--- a/Source/HTTPClient.h
+++ b/Source/HTTPClient.h
@@ -21,4 +21,6 @@
 
 BOOL HTTPGetFile (CTSTR url, CTSTR outputPath, CTSTR extraHeaders, int *responseCode);
 
+String HTTPGetString (CTSTR url, CTSTR extraHeaders, int *responseCode);
+
 String CreateHTTPURL(String host, String path, String extra=String(), bool secure=false);


### PR DESCRIPTION
Made the XConfig code capable of reading JSON. Might not be a perfect JSON parser but good enough. This was mainly acheived by supporting multiple terminators (specifically the comma as well as XConfig's \n).

A stream service can specify a web API call. If the URL starts with HTTP (instead of RTMP) then do an HTTP query on the URL (with a given stream/path/broadcaster key number). This webapi to return something like:
{"data":{"stream_url":"rtmp://some_url", "stream_name": "some-name"}}

This is the same information specified in the services.xconfig file. So the data returned in JSON is then passing to the stream startup as usual.
