### PR TITLE
Updated Hitbox's server list

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -94,7 +94,7 @@ services : {
       "South America" : rtmp://live.gru.hitbox.tv/push
       "South Korea"   : rtmp://live.icn.hitbox.tv/push
       "United Kingdom": rtmp://live.lhr.hitbox.tv/push
-      "Asia"          : rtmp://live.lax.hitbox.tv/push
+      "South America" : rtmp://live.gru.hitbox.tv/push
     }
     recommended : {
       "keyint" : 2000


### PR DESCRIPTION
The Asia server was a copy of "US-West". Since there is a Korean server now there is no need for this. Also added a South America server.

Source:
http://blog.hitbox.tv/the-monthly-guide-to-hitbox-updates/
