### PR TITLE
Change lower limit of video bitrate from 100kbps to 64kbps

### DIFF
--- a/Source/SettingsEncoding.cpp
+++ b/Source/SettingsEncoding.cpp
@@ -86,12 +86,14 @@ void SettingsEncoding::ApplySettings()
     if(quality != CB_ERR)
         AppConfig->SetInt(TEXT("Video Encoding"), TEXT("Quality"), quality);
 
+    static const int minBitRate = 64;
+
     UINT bitrate = GetEditText(GetDlgItem(hwnd, IDC_MAXBITRATE)).ToInt();
-    if(bitrate < 100) bitrate = 100;
+    if (bitrate < minBitRate) bitrate = minBitRate;
     AppConfig->SetInt(TEXT("Video Encoding"), TEXT("MaxBitrate"), bitrate);
 
     UINT bufSize = GetEditText(GetDlgItem(hwnd, IDC_BUFFERSIZE)).ToInt();
-    //if(bufSize < 100) bufSize = bitrate;  //R1CH: Allow users to enter 0 buffer size to disable VBV, its protected by checkbox anyway
+    //if(bufSize < minBitRate) bufSize = bitrate;  //R1CH: Allow users to enter 0 buffer size to disable VBV, its protected by checkbox anyway
     AppConfig->SetInt(TEXT("Video Encoding"), TEXT("BufferSize"), bufSize);
 
     if(App->GetVideoEncoder() != NULL) {


### PR DESCRIPTION
If we use high quality audio streaming by mp3 320kbps at NicoNicoLive
streaming service in Japan,
since the total bit rate has been limited to 384kbps, We hope to change
lower limit of video bitrate from 100kbps to 64kbps.
