### PR TITLE
lame: Use joint stereo

### DIFF
--- a/Source/Encoder_MP3.cpp
+++ b/Source/Encoder_MP3.cpp
@@ -62,9 +62,8 @@ public:
         lame_set_in_samplerate(lgf, App->GetSampleRateHz());
         lame_set_out_samplerate(lgf, App->GetSampleRateHz());
         lame_set_num_channels(lgf, App->NumAudioChannels());
-        //lame_set_mode(lgf, STEREO);
         if (App->NumAudioChannels()==2){
-            lame_set_mode(lgf, STEREO);
+            lame_set_mode(lgf, JOINT_STEREO);
         }
         if (App->NumAudioChannels()==1){
             lame_set_mode(lgf, MONO);


### PR DESCRIPTION
Joint stereo allows lame to pick the best encoding mode for each audio
frame.  With STEREO mode lame will always use separate encoding for each
audio channel which hurts quality (especially at lower bitrates).
