### PR TITLE
Fixed issue with windows not being found when using hotkey capture. Also...

### DIFF
--- a/GraphicsCapture/GraphicsCaptureSource.cpp
+++ b/GraphicsCapture/GraphicsCaptureSource.cpp
@@ -318,7 +318,8 @@ void GraphicsCaptureSource::BeginScene()
 
     drawShader = CreatePixelShaderFromFile(TEXT("shaders\\DrawTexture_ColorAdjust.pShader"));
 
-    AttemptCapture();
+    if (!bUseHotkey)
+        AttemptCapture();
 }
 
 BOOL GraphicsCaptureSource::CheckFileIntegrity(LPCTSTR strDLL)
@@ -372,7 +373,13 @@ void GraphicsCaptureSource::AttemptCapture()
     OSDebugOut(TEXT("attempting to capture..\n"));
 
     hwndTarget = strWindowClass.IsValid() ? FindVisibleWindow(strWindowClass, NULL) : nullptr;
+    
+    // use foregroundwindow as fallback (should be NULL if not using hotkey capture)
+    if (!hwndTarget)
+        hwndTarget = hwndNextTarget;
 
+    hwndNextTarget = nullptr;
+    
     OSDebugOut(L"Window: %s: ", strWindowClass.Array());
     if (hwndTarget)
     {
@@ -693,7 +700,6 @@ void GraphicsCaptureSource::Tick(float fSeconds)
                 strWindowClass.SetLength(255);
                 RealGetWindowClassW(hwndNextTarget, strWindowClass.Array(), 255);
                 strWindowClass.SetLength(slen(strWindowClass));
-                hwndNextTarget = NULL;
 
                 data->SetString(L"windowClass", strWindowClass);
             }


### PR DESCRIPTION
... fixed instant hooking of default window when calling BeginScene when using hotkey capture.

With the changes made to fix LoL hotkey capture (commit e3fcbb6), hotkey capturing specific games (Diablo1, Age of Empires1) stopped working. Quick fix was to fall back to the window handle received by GetForegroundWindow.
