### PR TITLE
Keep Global Sources in "sceneCollection/scenes.xconfig".

### DIFF
--- a/Source/API.cpp
+++ b/Source/API.cpp
@@ -476,7 +476,7 @@ public:
     }
 
     virtual XElement* GetSceneListElement()         {return App->scenesConfig.GetElement(TEXT("scenes"));}
-    virtual XElement* GetGlobalSourceListElement()  {return App->scenesConfig.GetElement(TEXT("global sources"));}
+    virtual XElement* GetGlobalSourceListElement()  {return App->globalSourcesConfig.GetElement(TEXT("global sources"));}
 
     virtual void SetSourceOrder(StringList &sourceNames)
     {

--- a/Source/GlobalSource.cpp
+++ b/Source/GlobalSource.cpp
@@ -91,7 +91,7 @@ bool STDCALL OBS::ConfigGlobalSource(XElement *element, bool bCreating)
     XElement *data = element->GetElement(TEXT("data"));
     CTSTR lpGlobalSourceName = data->GetString(TEXT("name"));
 
-    XElement *globalSources = App->scenesConfig.GetElement(TEXT("global sources"));
+    XElement *globalSources = App->globalSourcesConfig.GetElement(TEXT("global sources"));
     if(!globalSources) //shouldn't happen
         return false;
 
@@ -134,7 +134,7 @@ bool STDCALL OBS::ConfigGlobalSource(XElement *element, bool bCreating)
 
 ImageSource* OBS::AddGlobalSourceToScene(CTSTR lpName)
 {
-    XElement *globals = scenesConfig.GetElement(TEXT("global sources"));
+    XElement *globals = globalSourcesConfig.GetElement(TEXT("global sources"));
     if(globals)
     {
         XElement *globalSourceElement = globals->GetElement(lpName);
@@ -171,7 +171,7 @@ void OBS::GetGlobalSourceNames(List<CTSTR> &globalSourceNames)
 {
     globalSourceNames.Clear();
 
-    XElement *globals = scenesConfig.GetElement(TEXT("global sources"));
+    XElement *globals = globalSourcesConfig.GetElement(TEXT("global sources"));
     if(globals)
     {
         UINT numSources = globals->NumElements();
@@ -185,7 +185,7 @@ void OBS::GetGlobalSourceNames(List<CTSTR> &globalSourceNames)
 
 XElement* OBS::GetGlobalSourceElement(CTSTR lpName)
 {
-    XElement *globals = scenesConfig.GetElement(TEXT("global sources"));
+    XElement *globals = globalSourcesConfig.GetElement(TEXT("global sources"));
     if(globals)
         return globals->GetElement(lpName);
 

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -612,6 +612,7 @@ class OBS
     UINT                    encoderSkipThreshold;
 
     XConfig                 scenesConfig;
+    XConfig                 globalSourcesConfig;
     List<SceneHotkeyInfo>   sceneHotkeys;
     XElement                *sceneElement;
 
@@ -1020,6 +1021,7 @@ private:
     static void ResetSceneCollectionMenu();
     static void AddSceneCollectionToMenu(HMENU menu);
     void ReloadSceneCollection();
+    void RemoveDeletedGlobalSourcesFromScenes();
 
     static String GetApplicationName();
     static void ResetApplicationName();

--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -1830,7 +1830,7 @@ INT_PTR CALLBACK OBS::EnterGlobalSourceNameDialogProc(HWND hwnd, UINT message, W
 
                         String &strOut = *(String*)GetWindowLongPtr(hwnd, DWLP_USER);
 
-                        XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                        XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                         if(globals)
                         {
                             XElement *foundSource = globals->GetElement(str);
@@ -1863,7 +1863,7 @@ INT_PTR CALLBACK OBS::GlobalSourcesProc(HWND hwnd, UINT message, WPARAM wParam, 
                 LocalizeWindow(hwnd);
 
                 HWND hwndSources = GetDlgItem(hwnd, IDC_SOURCES);
-                XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                 if(globals)
                 {
                     UINT numGlobals = globals->NumElements();
@@ -1910,9 +1910,9 @@ INT_PTR CALLBACK OBS::GlobalSourcesProc(HWND hwnd, UINT message, WPARAM wParam, 
                         {
                             ClassInfo &ci = App->imageSourceClasses[classID-1];
 
-                            XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                            XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                             if(!globals)
-                                globals = App->scenesConfig.CreateElement(TEXT("global sources"));
+                                globals = App->globalSourcesConfig.CreateElement(TEXT("global sources"));
 
                             XElement *newSourceElement = globals->CreateElement(strName);
                             newSourceElement->SetString(TEXT("class"), ci.strClass);
@@ -1941,7 +1941,7 @@ INT_PTR CALLBACK OBS::GlobalSourcesProc(HWND hwnd, UINT message, WPARAM wParam, 
                         if(id == LB_ERR)
                             break;
 
-                        XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                        XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                         if(!globals)
                             break;
 
@@ -2056,7 +2056,7 @@ INT_PTR CALLBACK OBS::GlobalSourcesProc(HWND hwnd, UINT message, WPARAM wParam, 
                         if(id == LB_ERR)
                             break;
 
-                        XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                        XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                         if(!globals)
                             break;
 
@@ -2113,7 +2113,7 @@ INT_PTR CALLBACK OBS::GlobalSourcesProc(HWND hwnd, UINT message, WPARAM wParam, 
                         if(id == LB_ERR)
                             break;
 
-                        XElement *globals = App->scenesConfig.GetElement(TEXT("global sources"));
+                        XElement *globals = App->globalSourcesConfig.GetElement(TEXT("global sources"));
                         if(!globals)
                             break;
 


### PR DESCRIPTION
Instead of each Scene Collection having its own Global Sources. They are stored in and read from "sceneCollection/scenes.xconfig".

With this change users won't need to recreate their Global Sources for every new Scene Collection.

When a user deletes a Global Source it is removed from all Scene Collections.

The only issue I know is when a user renames a Global Source the user will need to add it back to the scene.
