### PR TITLE
Added "Copy To" in the scenes right click context menu

### DIFF
--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -621,6 +621,7 @@ class OBS
 
     XConfig                 scenesConfig;
     XConfig                 globalSourcesImportConfig;
+    XConfig                 scenesCopyToConfig;
     List<SceneHotkeyInfo>   sceneHotkeys;
     XElement                *sceneElement;
 

--- a/rundir/locale/en.txt
+++ b/rundir/locale/en.txt
@@ -50,6 +50,14 @@ ImportGlobalSources="Import Global Sources"
 ImportCollectionReplaceWarning.Title="Import Scene Collection"
 ImportCollectionReplaceWarning.Text="The current scene data will be lost.  Are you sure you want to import?"
 
+CopyTo="Copy To"
+CopyTo.SceneNameExists="The scene '$1' already exists in the selected scene collection."
+CopyTo.GlobalSourcesExists="The global source '$1' already exists in the selected scene collection."
+CopyTo.Success.Text="The scene '$1' has been successfully copied to the selected scene collection."
+CopyTo.Success.Title="Success"
+CopyTo.CopyGlobalSourcesReferences="Do you want to also copy the global sources the references point to? If you choose No the references will be removed from the copied scene."
+CopyTo.CopyGlobalSourcesReferences.Title="Copy the Global Sources?"
+
 DeleteCollection="Remove scene collection"
 DeleteCollection.Text="Are you sure you want to remove the current scene collection?"
 


### PR DESCRIPTION
I have added a "Copy To" menu item to the scenes right click context menu below "Copy".

When hovered over it will open a sub-menu where the user can then select the scene collection file the user wants to copy the selected scene to.

If there is a reference to a global source it will open a dialog asking the user if he/she wants to also copy the global sources the references point to.If the user clicks "No" the references are removed from the copied scene.If the global sources already exists in the target scene collection a dialog will open letting the user know but the scene is still copied.

A dialog will open telling the user the export was successful or the scene already exists in the selected scene collection.

I believe this is useful for users that want to copy or move scenes to a different scene collection.
