### PR TITLE
Update Hitbox Ingests.

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -85,16 +85,14 @@ services : {
     id : 11
     servers : {
       "Default"       : rtmp://live.hitbox.tv/push
-      "EU-East"       : rtmp://live.vie.hitbox.tv/push
-      "EU-Central"    : rtmp://live.nbg.hitbox.tv/push
       "EU-West"       : rtmp://live.fra.hitbox.tv/push
-      "EU-North"      : rtmp://live.ams.hitbox.tv/push
+      "EU-East"       : rtmp://live.vie.hitbox.tv/push
+      "EU-North"      : rtmp://live.lhr.hitbox.tv/push
+      "EU-Central"    : rtmp://live.nbg.hitbox.tv/push
       "US-East"       : rtmp://live.vgn.hitbox.tv/push
       "US-Central"    : rtmp://live.den.hitbox.tv/push
       "US-West"       : rtmp://live.lax.hitbox.tv/push
-      "South America" : rtmp://live.gru.hitbox.tv/push
       "South Korea"   : rtmp://live.icn.hitbox.tv/push
-      "United Kingdom": rtmp://live.lhr.hitbox.tv/push
       "South America" : rtmp://live.gru.hitbox.tv/push
     }
     recommended : {


### PR DESCRIPTION
The UK Ingest was changed into EU-North. (Where it was in the first place) and EU-North (Old) was live.ams.hitbox.tv which still works, but is not advertised in their API so I've removed it. I also decided not to add Asia as they have the ingest url marked as US_West. Which is obviously a mistake.

I also removed the duplicate of South America.

Changes were updated via their API. http://i.imgur.com/lwvM6tL.png (Image because the Ingest API requires auth.)
