### PR TITLE
Implement Profiles in menu only

### DIFF
--- a/OBS.rc
+++ b/OBS.rc
@@ -180,18 +180,15 @@ BEGIN
     COMBOBOX        IDC_LANGUAGE,146,22,226,126,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP
     RTEXT           "Settings.General.Profile",IDC_STATIC,7,44,138,8
     COMBOBOX        IDC_PROFILE,146,41,226,30,CBS_DROPDOWN | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Add",IDC_ADD,146,58,76,14
-    PUSHBUTTON      "Rename",IDC_RENAME,224,58,76,14
-    PUSHBUTTON      "Remove",IDC_REMOVE,302,58,70,14
     LTEXT           "Settings.General.Restart",IDC_INFO,7,160,409,48,NOT WS_VISIBLE
     CONTROL         "Settings.General.Notification",IDC_NOTIFICATIONICON,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,80,264,10,WS_EX_RIGHT
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,60,264,10,WS_EX_RIGHT
     CONTROL         "Settings.General.NotificationMinimize",IDC_MINIZENOTIFICATION,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,91,264,10,WS_EX_RIGHT
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,71,264,10,WS_EX_RIGHT
     CONTROL         "Settings.General.EnableProjectorCursor",IDC_ENABLEPROJECTORCURSOR,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,112,264,10,WS_EX_RIGHT
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,92,264,10,WS_EX_RIGHT
     CONTROL         "Settings.General.ShowLogWindowOnLaunch",IDC_SHOWLOGWINDOWONLAUNCH,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,133,264,10,WS_EX_RIGHT
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,113,264,10,WS_EX_RIGHT
 END
 
 IDD_SETTINGS_AUDIO DIALOGEX 0, 0, 427, 336
@@ -956,6 +953,14 @@ BEGIN
     END
     POPUP "MainMenu.Profiles"
     BEGIN
+        MENUITEM "MainMenu.Profiles.New", ID_PROFILE_NEW
+        MENUITEM "MainMenu.Profiles.Duplicate", ID_PROFILE_CLONE
+        MENUITEM "MainMenu.Profiles.Rename", ID_PROFILE_RENAME
+        MENUITEM "MainMenu.Profiles.Remove", ID_PROFILE_REMOVE
+        MENUITEM SEPARATOR
+        MENUITEM "MainMenu.Profiles.Import", ID_PROFILE_IMPORT
+        MENUITEM "MainMenu.Profiles.Export", ID_PROFILE_EXPORT
+        MENUITEM SEPARATOR
         MENUITEM "nothing here",                ID_MAINMENU_NOTHINGHERE
     END
     POPUP "MainMenu.SceneCollection"

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -602,6 +602,12 @@ enum class SceneCollectionAction {
     Clone
 };
 
+enum class ProfileAction {
+    Add,
+    Rename,
+    Clone
+};
+
 struct ReplayBuffer;
 void SaveReplayBuffer(ReplayBuffer *out, DWORD timestamp);
 
@@ -1100,6 +1106,11 @@ private:
     void CallHotkey(DWORD hotkeyID, bool bDown);
 
     static void AddProfilesToMenu(HMENU menu);
+    static INT_PTR CALLBACK EnterProfileDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    void AddProfile(ProfileAction action);
+    void RemoveProfile();
+    void ImportProfile();
+    void ExportProfile();
     static void ResetProfileMenu();
     static void ResetLogUploadMenu();
     static void DisableMenusWhileStreaming(bool disable);

--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -130,6 +130,61 @@ INT_PTR CALLBACK OBS::EnterSceneCollectionDialogProc(HWND hwnd, UINT message, WP
     return false;
 }
 
+INT_PTR CALLBACK OBS::EnterProfileDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch (message)
+    {
+        case WM_INITDIALOG:
+            {
+                SetWindowLongPtr(hwnd, DWLP_USER, (LONG_PTR)lParam);
+                LocalizeWindow(hwnd);
+
+                String &strOut = *(String*)GetWindowLongPtr(hwnd, DWLP_USER);
+                SetWindowText(GetDlgItem(hwnd, IDC_NAME), strOut);
+
+                return true;
+            }
+
+        case WM_COMMAND:
+            switch (LOWORD(wParam))
+            {
+                case IDOK:
+                    {
+                        String str;
+                        str.SetLength((UINT)SendMessage(GetDlgItem(hwnd, IDC_NAME), WM_GETTEXTLENGTH, 0, 0));
+                        if (!str.Length())
+                        {
+                            OBSMessageBox(hwnd, Str("EnterName"), NULL, 0);
+                            break;
+                        }
+
+                        SendMessage(GetDlgItem(hwnd, IDC_NAME), WM_GETTEXT, str.Length()+1, (LPARAM)str.Array());
+
+                        String &strOut = *(String*)GetWindowLongPtr(hwnd, DWLP_USER);
+
+                        String strProfilePath;
+                        strProfilePath << lpAppDataPath << TEXT("\\profiles\\") << str << TEXT(".ini");
+
+                        if (OSFileExists(strProfilePath))
+                        {
+                            String strExists = Str("NameExists");
+                            strExists.FindReplace(TEXT("$1"), str);
+                            OBSMessageBox(hwnd, strExists, NULL, 0);
+                            break;
+                        }
+
+                        strOut = str;
+                    }
+
+                case IDCANCEL:
+                    EndDialog(hwnd, LOWORD(wParam));
+                    break;
+            }
+    }
+
+    return false;
+}
+
 INT_PTR CALLBACK OBS::EnterSourceNameDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch(message)
@@ -2862,6 +2917,204 @@ void OBS::ExportSceneCollection()
 
 //----------------------------
 
+void OBS::AddProfile(ProfileAction action)
+{
+    if (App->bRunning)
+        return;
+
+    String strCurProfile = GlobalConfig->GetString(TEXT("General"), TEXT("Profile"));
+
+    String strProfile;
+    if (action == ProfileAction::Rename)
+        strProfile = strCurProfile;
+
+    if (OBSDialogBox(hinstMain, MAKEINTRESOURCE(IDD_ENTERNAME), hwndMain, OBS::EnterProfileDialogProc, (LPARAM)&strProfile) != IDOK)
+        return;
+
+    String strCurProfilePath;
+    strCurProfilePath = FormattedString(L"%s\\profiles\\%s.ini", lpAppDataPath, strCurProfile.Array());
+
+    String strProfilePath;
+    strProfilePath << lpAppDataPath << TEXT("\\profiles\\") << strProfile << TEXT(".ini");
+
+    if ((action != ProfileAction::Rename || !strProfilePath.CompareI(strCurProfilePath)) && OSFileExists(strProfilePath))
+        OBSMessageBox(hwndMain, Str("MainMenu.Profiles.ProfileExists"), NULL, 0);
+    else
+    {
+        bool success = true;
+
+        if (action == ProfileAction::Rename)
+        {
+            if (!MoveFile(strCurProfilePath, strProfilePath))
+                success = false;
+            AppConfig->SetFilePath(strProfilePath);
+        }
+        else if (action == ProfileAction::Clone)
+        {
+            if (!CopyFileW(strCurProfilePath, strProfilePath, TRUE))
+                success = false;
+        }
+        else
+        {
+            if(!AppConfig->Create(strProfilePath))
+            {
+                OBSMessageBox(hwndMain, TEXT("Error - unable to create new profile, could not create file"), NULL, 0);
+                return;
+            }
+        }
+
+        if (!success)
+        {
+            AppConfig->Open(strCurProfilePath);
+            return;
+        }
+
+        GlobalConfig->SetString(TEXT("General"), TEXT("Profile"), strProfile);
+
+        App->ReloadIniSettings();
+        App->ResetProfileMenu();
+        App->ResetApplicationName();
+    }
+}
+
+void OBS::RemoveProfile()
+{
+    if (App->bRunning)
+        return;
+
+    String strCurProfile = GlobalConfig->GetString(TEXT("General"), TEXT("Profile"));
+
+    String strCurProfileFile = strCurProfile + L".ini";
+    String strCurProfileDir;
+    strCurProfileDir << lpAppDataPath << TEXT("\\profiles\\");
+
+    OSFindData ofd;
+    HANDLE hFind = OSFindFirstFile(strCurProfileDir + L"*.ini", ofd);
+
+    if (!hFind)
+    {
+        Log(L"Find failed for profile");
+        return;
+    }
+
+    String nextFile;
+
+    do
+    {
+        if (scmpi(ofd.fileName, strCurProfileFile) != 0)
+        {
+            nextFile = ofd.fileName;
+            break;
+        }
+    } while (OSFindNextFile(hFind, ofd));
+    OSFindClose(hFind);
+
+    if (nextFile.IsEmpty())
+        return;
+
+    String strConfirm = Str("Settings.General.ConfirmDelete");
+    strConfirm.FindReplace(TEXT("$1"), strCurProfile);
+    if (OBSMessageBox(hwndMain, strConfirm, Str("DeleteConfirm.Title"), MB_YESNO) == IDYES)
+    {
+        String strCurProfilePath;
+        strCurProfilePath << strCurProfileDir << strCurProfile << TEXT(".ini");
+        OSDeleteFile(strCurProfilePath);
+
+        GlobalConfig->SetString(L"General", L"Profile", GetPathWithoutExtension(nextFile));
+
+        App->ReloadIniSettings();
+        App->ResetApplicationName();
+        App->ResetProfileMenu();
+    }
+}
+
+void OBS::ImportProfile()
+{
+    if (OBSMessageBox(hwndMain, Str("ImportProfileReplaceWarning.Text"), Str("ImportProfileReplaceWarning.Title"), MB_YESNO) == IDNO)
+        return;
+
+    TCHAR lpFile[MAX_PATH+1];
+    zero(lpFile, sizeof(lpFile));
+
+    OPENFILENAME ofn;
+    zero(&ofn, sizeof(ofn));
+    ofn.lStructSize = sizeof(ofn);
+    ofn.lpstrFile = lpFile;
+    ofn.hwndOwner = hwndMain;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.lpstrFilter = TEXT("Profile Files (*.ini)\0*.ini\0");
+    ofn.nFilterIndex = 1;
+    ofn.lpstrInitialDir = GlobalConfig->GetString(L"General", L"LastImportExportPath");
+
+    TCHAR curDirectory[MAX_PATH+1];
+    GetCurrentDirectory(MAX_PATH, curDirectory);
+
+    BOOL bOpenFile = GetOpenFileName(&ofn);
+    SetCurrentDirectory(curDirectory);
+
+    if (!bOpenFile)
+        return;
+
+    if (GetPathExtension(lpFile).IsEmpty())
+        scat(lpFile, L".ini");
+
+    GlobalConfig->SetString(L"General", L"LastImportExportPath", GetPathDirectory(lpFile));
+
+    String strCurProfile = GlobalConfig->GetString(TEXT("General"), TEXT("Profile"));
+    String strCurProfileFile;
+    strCurProfileFile << lpAppDataPath << TEXT("\\profiles\\") << strCurProfile << L".ini";
+
+    CopyFile(lpFile, strCurProfileFile, false);
+
+    if(!AppConfig->Open(strCurProfileFile))
+    {
+        OBSMessageBox(hwndMain, TEXT("Error - unable to open ini file"), NULL, 0);
+        return;
+    }
+
+    App->ReloadIniSettings();
+}
+
+void OBS::ExportProfile()
+{
+    TCHAR lpFile[MAX_PATH+1];
+    zero(lpFile, sizeof(lpFile));
+
+    OPENFILENAME ofn;
+    zero(&ofn, sizeof(ofn));
+    ofn.lStructSize = sizeof(ofn);
+    ofn.lpstrFile = lpFile;
+    ofn.hwndOwner = hwndMain;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.lpstrFilter = TEXT("Profile Files (*.ini)\0*.ini\0");
+    ofn.nFilterIndex = 1;
+    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+    ofn.lpstrInitialDir = GlobalConfig->GetString(L"General", L"LastImportExportPath");
+
+    TCHAR curDirectory[MAX_PATH+1];
+    GetCurrentDirectory(MAX_PATH, curDirectory);
+
+    BOOL bSaveFile = GetSaveFileName(&ofn);
+    SetCurrentDirectory(curDirectory);
+
+    if (!bSaveFile)
+        return;
+
+    if (GetPathExtension(lpFile).IsEmpty())
+        scat(lpFile, L".ini");
+
+    String strCurProfile = GlobalConfig->GetString(TEXT("General"), TEXT("Profile"));
+    String strCurProfileFile;
+    strCurProfileFile << lpAppDataPath << TEXT("\\profiles\\") << strCurProfile << L".ini";
+
+    GlobalConfig->SetString(L"General", L"LastImportExportPath", GetPathDirectory(lpFile));
+
+    CopyFile(strCurProfileFile, lpFile,  false);
+}
+
+
+//----------------------------
+
 void OBS::ResetSceneCollectionMenu()
 {
     HMENU hmenuMain = GetMenu(hwndMain);
@@ -2874,7 +3127,7 @@ void OBS::ResetProfileMenu()
 {
     HMENU hmenuMain = GetMenu(hwndMain);
     HMENU hmenuProfiles = GetSubMenu(hmenuMain, 2);
-    while (DeleteMenu(hmenuProfiles, 0, MF_BYPOSITION));
+    while (DeleteMenu(hmenuProfiles, 8, MF_BYPOSITION));
     AddProfilesToMenu(hmenuProfiles);
 }
 
@@ -3527,6 +3780,25 @@ LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
                     break;
                 case ID_SCENECOLLECTION_EXPORT:
                     App->ExportSceneCollection();
+                    break;
+
+                case ID_PROFILE_NEW:
+                    App->AddProfile(ProfileAction::Add);
+                    break;
+                case ID_PROFILE_CLONE:
+                    App->AddProfile(ProfileAction::Clone);
+                    break;
+                case ID_PROFILE_RENAME:
+                    App->AddProfile(ProfileAction::Rename);
+                    break;
+                case ID_PROFILE_REMOVE:
+                    App->RemoveProfile();
+                    break;
+                case ID_PROFILE_IMPORT:
+                    App->ImportProfile();
+                    break;
+                case ID_PROFILE_EXPORT:
+                    App->ExportProfile();
                     break;
 
                 case ID_TESTSTREAM:

--- a/resource.h
+++ b/resource.h
@@ -433,13 +433,19 @@
 #define ID_SCENECOLLECTION_IMPORT       40079
 #define ID_SCENECOLLECTION_EXPORT       40080
 #define ID_SAVEDREPLAYBUFFERS           40081
+#define ID_PROFILE_NEW                  40082
+#define ID_PROFILE_RENAME               40083
+#define ID_PROFILE_CLONE                40084
+#define ID_PROFILE_REMOVE               40085
+#define ID_PROFILE_IMPORT               40086
+#define ID_PROFILE_EXPORT               40087
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        152
-#define _APS_NEXT_COMMAND_VALUE         40082
+#define _APS_NEXT_COMMAND_VALUE         40088
 #define _APS_NEXT_CONTROL_VALUE         1209
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/rundir/locale/en.txt
+++ b/rundir/locale/en.txt
@@ -59,6 +59,9 @@ CopyTo.Success.Title="Success"
 CopyTo.CopyGlobalSourcesReferences="Do you want to also copy the global sources the references point to? If you choose No the references will be removed from the copied scene."
 CopyTo.CopyGlobalSourcesReferences.Title="Copy the Global Sources?"
 
+ImportProfileReplaceWarning.Title="Import Profile"
+ImportProfileReplaceWarning.Text="The current profile data will be lost.  Are you sure you want to import?"
+
 DeleteCollection="Remove scene collection"
 DeleteCollection.Text="Are you sure you want to remove the current scene collection?"
 
@@ -103,6 +106,14 @@ MainMenu.File="&File"
 MainMenu.Help="&Help"
 MainMenu.Profiles="&Profiles"
 MainMenu.Settings="&Settings"
+
+MainMenu.Profiles.New="&New"
+MainMenu.Profiles.Duplicate="&Duplicate"
+MainMenu.Profiles.Rename="&Rename"
+MainMenu.Profiles.Remove="Re&move"
+MainMenu.Profiles.Import="&Import"
+MainMenu.Profiles.Export="&Export"
+MainMenu.Profiles.ProfileExists="A profile with the same name already exists."
 
 MainMenu.Settings.AlwaysOnTop="&Always On Top"
 MainMenu.Settings.FullscreenMode="&Fullscreen Preview Mode"


### PR DESCRIPTION
I have implemented the same menu as scene collections. 

The profile menu now has:
- New
- Duplicate
- Rename
- Remove
- Import
- Export

It functions the same but for profiles. 

I have removed the Add/Rename/Remove from settings general. I have left
the profile combo box because it is still useful when a user wants to
switch to a different profile while in settings.
