### PR TITLE
Fixed a bug with "copyTo" that only effected the 64bit version of obs

### DIFF
--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -505,7 +505,7 @@ LRESULT CALLBACK OBS::ListboxHook(HWND hwnd, UINT message, WPARAM wParam, LPARAM
                         UINT classID = ret - ID_LISTBOX_COPYTO;
 
                         String strScenesCopyToConfig;
-                        strScenesCopyToConfig = FormattedString(L"%s\\sceneCollection\\%s.xconfig", lpAppDataPath, sceneCollectionList[classID]);
+                        strScenesCopyToConfig = FormattedString(L"%s\\sceneCollection\\%s.xconfig", lpAppDataPath, sceneCollectionList[classID].Array());
 
                         if(!App->scenesCopyToConfig.Open(strScenesCopyToConfig))
                             CrashError(TEXT("Could not open '%s"), strScenesCopyToConfig.Array());


### PR DESCRIPTION
I have fixed a bug when a user uses obs 64bit and  copies a scene to a
different scene collection it would instead of copying to the target
scene collection it would copy it to a new scene collection with what
looks like Chinese characters as the new scene collection's name. This
bug only happened in the 64bit version of obs.
