### PR TITLE
Removed live-ord.twitch.tv from the ingest list

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -14,7 +14,6 @@ services : {
       "US East: Ashburn, VA"                 : rtmp://live-iad.twitch.tv/app
       "US East: Miami, FL"                   : rtmp://live-mia.twitch.tv/app
       "US East: New York, NY"                : rtmp://live-jfk.twitch.tv/app
-      "US Midwest: Chicago, IL"              : rtmp://live-ord.twitch.tv/app
       "US West: Los Angeles, CA"             : rtmp://live-lax.twitch.tv/app
     }
     recommended : {


### PR DESCRIPTION
Chicago is out of commission as posted in the blogpost here: http://blog.twitch.tv/2014/09/service-update-chicago-point-of-presence-closure/
Also the dns entry for live-ord.twitch.tv got removed and therefor people trying to use it will get an error.
