### PR TITLE
remove information for Nico Nico live broadcast

### DIFF
--- a/rundir/locale/ja.txt
+++ b/rundir/locale/ja.txt
@@ -125,7 +125,7 @@ MainMenu.Settings.OpenConfigFolder="設定フォルダーを開く(&C)"
 MainMenu.Settings.OpenLogFolder="ログフォルダーを開く(&L)"
 MainMenu.Settings.ShowLogWindow="ログウィンドウを表示"
 
-MainWindow.BeginMessage="[ 配信停止中 ] - \"配信開始\"、\"録画開始\"、または\"配信プレビュー\"をクリックして開始して下さい\n\n※ニコニコ生放送の場合、OBSのアップデート時には自動化ツールの最新の対応版を確認してください"
+MainWindow.BeginMessage="[ 配信停止中 ] - \"配信開始\"、\"録画開始\"、または\"配信プレビュー\"をクリックして開始して下さい"
 MainWindow.PreviewDisabled="プレビューが無効化されました\n\n右クリックして「プレビュー」を選択し、再度有効にする場合は「ビューを有効にする」を選択してください。"
 MainWindow.Dashboard="ダッシュボード"
 MainWindow.DroppedFrames="処理落ちしたフレーム:"


### PR DESCRIPTION
i have deleted this sentence:
  "In the case of Nico Nico live broadcast , please make sure the latest supported version of the automation tool during OBS update"
i think it should not support the services of one particular company.
