### PR TITLE
Allow plugins to toggle the default transition via the API

### DIFF
--- a/OBSApi/APIDefs.cpp
+++ b/OBSApi/APIDefs.cpp
@@ -64,6 +64,10 @@ Scene* OBSGetScene()            {return API->GetScene();}
 CTSTR OBSGetSceneName()         {return API->GetSceneName();}
 XElement* OBSGetSceneElement()  {return API->GetSceneElement();}
 
+void OBSDisableTransitions()    { API->DisableTransitions(); }
+void OBSEnableTransitions()     { API->EnableTransitions(); }
+bool OBSTransitionsEnabled()    { return API->TransitionsEnabled(); }
+
 bool OBSSetSceneCollection(CTSTR lpCollection, CTSTR lpScene)
 {
     return API->SetSceneCollection(lpCollection, lpScene);

--- a/OBSApi/APIInterface.h
+++ b/OBSApi/APIInterface.h
@@ -197,6 +197,10 @@ public:
     virtual bool SetSceneCollection(CTSTR lpCollection, CTSTR lpScene) = 0;
     virtual CTSTR GetSceneCollectionName() const = 0;
     virtual void GetSceneCollectionNames(StringList &list) const = 0;
+
+    virtual void DisableTransitions() = 0;
+    virtual void EnableTransitions() = 0;
+    virtual bool TransitionsEnabled() const = 0;
 };
 
 BASE_EXPORT extern APIInterface *API;
@@ -225,6 +229,10 @@ BASE_EXPORT XElement* OBSGetSceneElement();
 BASE_EXPORT bool OBSSetSceneCollection(CTSTR lpCollection, CTSTR lpScene);
 BASE_EXPORT CTSTR OBSGetSceneCollectionName();
 BASE_EXPORT void OBSGetSceneCollectionNames(StringList &list);
+
+BASE_EXPORT void OBSDisableTransitions();
+BASE_EXPORT void OBSEnableTransitions();
+BASE_EXPORT bool OBSTransitionsEnabled();
 
 //low-order word is VK, high-order word is modifier.  equivalent to the value given by hotkey controls
 BASE_EXPORT UINT OBSCreateHotkey(DWORD hotkey, OBSHOTKEYPROC hotkeyProc, UPARAM param);

--- a/Source/API.cpp
+++ b/Source/API.cpp
@@ -264,7 +264,7 @@ bool OBS::SetScene(CTSTR lpScene)
     bChangingSources = true;
     ListView_DeleteAllItems(hwndSources);
 
-    bool bSkipTransition = false;
+    bool bSkipTransition = !performTransition;
 
     XElement *sources = sceneElement->GetElement(TEXT("sources"));
     if(sources)
@@ -679,6 +679,9 @@ public:
     }
     virtual CTSTR GetSceneCollectionName() const { return App->GetCurrentSceneCollection(); }
     virtual void GetSceneCollectionNames(StringList &list) const { return App->GetSceneCollection(list); }
+    virtual void DisableTransitions()          { App->performTransition = false; }
+    virtual void EnableTransitions()           { App->performTransition = true; }
+    virtual bool TransitionsEnabled() const    { return App->performTransition; }
 };
 
 APIInterface* CreateOBSApiInterface()

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -130,6 +130,8 @@ OBS::OBS()
 {
     App = this;
 
+    performTransition = true;        //Default to true and don't set the conf. 
+                                     //We don't want to let plugins disable standard behavior permanently.
     hSceneMutex = OSCreateMutex();
     hAuxAudioMutex = OSCreateMutex();
     hVideoEvent = CreateEvent(NULL, FALSE, FALSE, NULL);

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -643,6 +643,7 @@ class OBS
     Texture *lastRenderTexture;
     Texture *transitionTexture;
 
+    bool    performTransition;
     bool    bTransitioning;
     float   transitionAlpha;
 


### PR DESCRIPTION
I was trying as hard as I could to circumvent the default transition effect without modifying any OBS code but I couldn't find a workable solution. Here is a small patch that, if added, will allow plugin developers to have a lot more flexibility in terms of developing custom transitions.