### PR TITLE
Small fix for Start/Stop streaming button label when previewing

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1390,7 +1390,7 @@ void OBS::ConfigureStreamButtons()
         return PostConfigureStreamButtons();
 
     RefreshStreamButtons();
-    SetWindowText(GetDlgItem(hwndMain, ID_STARTSTOP), bStreaming ? Str("MainWindow.StopStream") : Str("MainWindow.StartStream"));
+    SetWindowText(GetDlgItem(hwndMain, ID_STARTSTOP), (bStreaming && !bTestStream) ? Str("MainWindow.StopStream") : Str("MainWindow.StartStream"));
     SetWindowText(GetDlgItem(hwndMain, ID_TOGGLERECORDING), bRecording ? Str("MainWindow.StopRecording") : Str("MainWindow.StartRecording"));
     SetWindowText(GetDlgItem(hwndMain, ID_TESTSTREAM), bTestStream ? Str("MainWindow.StopTest") : Str("MainWindow.TestStream"));
 }


### PR DESCRIPTION
When starting preview the Start/Stop Streaming button label changes to Stop Streaming.
This PR fixes it.
