### PR TITLE
Elgato force buffering

### DIFF
--- a/DShowPlugin/DShowPlugin.cpp
+++ b/DShowPlugin/DShowPlugin.cpp
@@ -1917,6 +1917,17 @@ INT_PTR CALLBACK ConfigureDialogProc(HWND hwnd, UINT message, WPARAM wParam, LPA
                             double minFPS = 10000000.0/double(fpsInfo.supportedIntervals[i].maxFrameInterval);
                             double maxFPS = 10000000.0/double(fpsInfo.supportedIntervals[i].minFrameInterval);
 
+#if 1 // FMB NOTE 05-Feb-15: Override some common fps values to avoid rounding errors (60.002 was displayed instead of 60 fps for the Elgato GCHD60)
+                            if (fpsInfo.supportedIntervals[i].maxFrameInterval == 400000) minFPS = 25.0;
+                            if (fpsInfo.supportedIntervals[i].minFrameInterval == 400000) maxFPS = 25.0;
+                            if (fpsInfo.supportedIntervals[i].maxFrameInterval == 200000) minFPS = 50.0;
+                            if (fpsInfo.supportedIntervals[i].minFrameInterval == 200000) maxFPS = 50.0;
+                            if (fpsInfo.supportedIntervals[i].maxFrameInterval == 333333) minFPS = 30.0;
+                            if (fpsInfo.supportedIntervals[i].minFrameInterval == 333333) maxFPS = 30.0;
+                            if (fpsInfo.supportedIntervals[i].maxFrameInterval == 166666) minFPS = 60.0;
+                            if (fpsInfo.supportedIntervals[i].minFrameInterval == 166666) maxFPS = 60.0;
+#endif
+
                             String strFPS;
                             if(CloseDouble(minFPS, maxFPS))
                                 strFPS << FloatString(float(minFPS));

--- a/DShowPlugin/DShowPlugin.cpp
+++ b/DShowPlugin/DShowPlugin.cpp
@@ -436,6 +436,11 @@ IPin* GetOutputPin(IBaseFilter *filter, const GUID *majorType)
     return foundPin;
 }
 
+// ELGATO_WORKAROUND: Not necessary anymore since Elgato Game Capture v.2.20 which implements IAMStreamConfig
+//                    !!! Keep this enabled nonetheless for backwards compatibility !!!
+#define ELGATO_WORKAROUND 1
+
+#if ELGATO_WORKAROUND
 static void AddElgatoRes(AM_MEDIA_TYPE *pMT, int cx, int cy, VideoOutputType type, List<MediaOutputInfo> &outputInfoList)
 {
     MediaOutputInfo *outputInfo = outputInfoList.CreateNew();
@@ -454,6 +459,7 @@ static void AddElgatoRes(AM_MEDIA_TYPE *pMT, int cx, int cy, VideoOutputType typ
     outputInfo->videoType = type;
     outputInfo->bUsingFourCC = false;
 }
+#endif
 
 void AddOutput(AM_MEDIA_TYPE *pMT, BYTE *capsData, bool bAllowV2, List<MediaOutputInfo> &outputInfoList)
 {
@@ -474,7 +480,8 @@ void AddOutput(AM_MEDIA_TYPE *pMT, BYTE *capsData, bool bAllowV2, List<MediaOutp
 
         if(type != VideoOutputType_None)
         {
-            if (!pVSCC && bAllowV2)
+#if ELGATO_WORKAROUND // FMB NOTE 18-Feb-14: Not necessary anymore since Elgato Game Capture v.2.20 which implements IAMStreamConfig
+            if (!pVSCC && bAllowV2)	 
             {
                 AddElgatoRes(pMT, 480,  360,  type, outputInfoList);
                 AddElgatoRes(pMT, 640,  480,  type, outputInfoList);
@@ -483,6 +490,7 @@ void AddOutput(AM_MEDIA_TYPE *pMT, BYTE *capsData, bool bAllowV2, List<MediaOutp
                 DeleteMediaType(pMT);
                 return;
             }
+#endif
 
             MediaOutputInfo *outputInfo = outputInfoList.CreateNew();
 
@@ -512,7 +520,7 @@ void AddOutput(AM_MEDIA_TYPE *pMT, BYTE *capsData, bool bAllowV2, List<MediaOutp
                 if(pVih->AvgTimePerFrame != 0)
                     outputInfo->minFrameInterval = outputInfo->maxFrameInterval = pVih->AvgTimePerFrame;
                 else
-                    outputInfo->minFrameInterval = outputInfo->maxFrameInterval = 10000000/30; //elgato hack
+                    outputInfo->minFrameInterval = outputInfo->maxFrameInterval = 10000000/30; //elgato hack // FMB NOTE 18-Feb-14: Not necessary anymore since Elgato Game Capture v.2.20 which implements IAMStreamConfig
 
                 outputInfo->xGranularity = outputInfo->yGranularity = 1;
             }

--- a/DShowPlugin/DShowPlugin.cpp
+++ b/DShowPlugin/DShowPlugin.cpp
@@ -326,7 +326,7 @@ bool PinHasMajorType(IPin *pin, const GUID *majorType)
             int priority = -1;
             for(int i=0; i<count; i++)
             {
-                AM_MEDIA_TYPE *pMT;
+                AM_MEDIA_TYPE *pMT = nullptr;
                 if(SUCCEEDED(config->GetStreamCaps(i, &pMT, capsData)))
                 {
                     BOOL bDesiredMediaType = (pMT->majortype == *majorType);
@@ -543,7 +543,7 @@ void GetOutputList(IPin *curPin, List<MediaOutputInfo> &outputInfoList)
             int priority = -1;
             for(int i=0; i<count; i++)
             {
-                AM_MEDIA_TYPE *pMT;
+                AM_MEDIA_TYPE *pMT = nullptr;
                 if(SUCCEEDED(config->GetStreamCaps(i, &pMT, capsData)))
                     AddOutput(pMT, capsData, false, outputInfoList);
             }

--- a/DShowPlugin/DeviceSource.cpp
+++ b/DShowPlugin/DeviceSource.cpp
@@ -37,7 +37,7 @@ enum
         EXTERN_C const GUID DECLSPEC_SELECTANY name \
                 = { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }
 
-#include "IVideoCaptureFilter.h"
+#include "IVideoCaptureFilter.h" // for Elgato GameCapture
 
 DWORD STDCALL PackPlanarThread(ConvertData *data);
 
@@ -1813,9 +1813,9 @@ void DeviceSource::UpdateSettings()
     if(strNewAudioDevice == "Disable" && strAudioDevice == "Disable")
         bCheckSoundOutput = false;
 
-    bool eglato = sstri(strNewDevice.Array(), L"elgato") != nullptr;
+    bool elgato = sstri(strNewDevice.Array(), L"elgato") != nullptr;
 
-    if(eglato || (bNewUseAudioRender != bUseAudioRender && bCheckSoundOutput) ||
+    if(elgato || (bNewUseAudioRender != bUseAudioRender && bCheckSoundOutput) ||
        (newSoundOutputType != soundOutputType && bCheckSoundOutput) || imageCX != newCX || imageCY != newCY ||
        frameIntervalDiff >= 10 || newPreferredType != preferredOutputType ||
        !strDevice.CompareI(strNewDevice) || !strAudioDevice.CompareI(strNewAudioDevice) ||

--- a/DShowPlugin/DeviceSource.cpp
+++ b/DShowPlugin/DeviceSource.cpp
@@ -67,6 +67,7 @@ void ElgatoCheckBuffering(IBaseFilter* deviceFilter, bool& argUseBuffering, UINT
             {
                 argUseBuffering = true;
                 argBufferTime = elgatoHD60MinBufferTime;
+                Log(TEXT("    Elgato Game Capture HD60: force buffering with %d msec"), elgatoHD60MinBufferTime / 10000);
             }
         }
         elgatoFilterInterface4->Release();

--- a/DShowPlugin/DeviceSource.cpp
+++ b/DShowPlugin/DeviceSource.cpp
@@ -50,27 +50,19 @@ DWORD STDCALL PackPlanarThread(ConvertData *data);
 #if ELGATO_FORCE_BUFFERING
 // FMB NOTE 03-Feb-15: Workaround for Elgato Game Capture HD60 which plays jerky unless we add a little buffering.
 // The buffer time for this workaround is so small that it shouldn't affect sync with other sources.
+// FMB NOTE 18-Feb-15: Enable buffering for every Elgato device because to make sure device timestamps are used.
+//                     Should improve sync issues.
 
 // param argBufferTime - 100-nsec unit (same as REFERENCE_TIME)
 void ElgatoCheckBuffering(IBaseFilter* deviceFilter, bool& argUseBuffering, UINT& argBufferTime)
 {
-    const int elgatoHD60MinBufferTime = 1 * 10000;	// 1 msec
+    const int elgatoMinBufferTime = 1 * 10000;	// 1 msec
 
-    IElgatoVideoCaptureFilter4* elgatoFilterInterface4 = nullptr;
-    if (SUCCEEDED(deviceFilter->QueryInterface(IID_IElgatoVideoCaptureFilter4, (void**)&elgatoFilterInterface4)))
+    if (!argUseBuffering || argBufferTime < elgatoMinBufferTime)
     {
-        VIDEO_CAPTURE_FILTER_DEVICE_TYPE deviceType;
-        if (SUCCEEDED(elgatoFilterInterface4->GetDeviceType(&deviceType))
-            && (VIDEO_CAPTURE_FILTER_DEVICE_TYPE_GAME_CAPTURE_HD60 == deviceType))
-        {
-            if (!argUseBuffering || argBufferTime < elgatoHD60MinBufferTime)
-            {
-                argUseBuffering = true;
-                argBufferTime = elgatoHD60MinBufferTime;
-                Log(TEXT("    Elgato Game Capture HD60: force buffering with %d msec"), elgatoHD60MinBufferTime / 10000);
-            }
-        }
-        elgatoFilterInterface4->Release();
+        argUseBuffering = true;
+        argBufferTime = elgatoMinBufferTime;
+        Log(TEXT("    Elgato Game Capture: force buffering with %d msec"), elgatoMinBufferTime / 10000);
     }
 }
 #endif // ELGATO_FORCE_BUFFERING

--- a/DShowPlugin/DeviceSource.cpp
+++ b/DShowPlugin/DeviceSource.cpp
@@ -50,7 +50,7 @@ DWORD STDCALL PackPlanarThread(ConvertData *data);
 #if ELGATO_FORCE_BUFFERING
 // FMB NOTE 03-Feb-15: Workaround for Elgato Game Capture HD60 which plays jerky unless we add a little buffering.
 // The buffer time for this workaround is so small that it shouldn't affect sync with other sources.
-// FMB NOTE 18-Feb-15: Enable buffering for every Elgato device because to make sure device timestamps are used.
+// FMB NOTE 18-Feb-15: Enable buffering for every Elgato device to make sure device timestamps are used.
 //                     Should improve sync issues.
 
 // param argBufferTime - 100-nsec unit (same as REFERENCE_TIME)

--- a/DShowPlugin/DeviceSource.h
+++ b/DShowPlugin/DeviceSource.h
@@ -177,7 +177,7 @@ class DeviceSource : public ImageSource
     HANDLE          hStopSampleEvent;
     HANDLE          hSampleMutex;
     HANDLE          hSampleThread;
-    UINT            bufferTime;
+    UINT            bufferTime;				// 100-nsec units (same as REFERENCE_TIME)
     SampleData      *latestVideoSample;
     List<SampleData*> samples;
 

--- a/DShowPlugin/IVideoCaptureFilter.h
+++ b/DShowPlugin/IVideoCaptureFilter.h
@@ -4,15 +4,19 @@
 //! @ec @brief   Interface declaration for Elgato Video Capture Filter
 //! @author      F.M.Birth, T.Schnitzler
 //! @date        01-Oct-12 FMB - Creation
-//! @date        08-Apr-13 TS  - Added IVideoCaptureFilter2
-//! @date        14-Nov-13 TS  - Added IVideoCaptureFilter3
-//! @date        21-Jul-14 TS  - Added IVideoCaptureFilter4
-//! @date        12-Aug-14 TS  - Added IVideoCaptureFilter5
+//! @date        08-Apr-13 TS  - Added <i>IVideoCaptureFilter2</i>
+//! @date        14-Nov-13 TS  - Added <i>IVideoCaptureFilter3</i>
+//! @date        21-Jul-14 TS  - Added <i>IVideoCaptureFilter4</i>
 //! @date        28-Aug-14 FDj - MIT license added
-//! @note        Supports Elgato Game Capture HD
+//! @date        04-Sep-14 FMB - Added <i>interfaceVersion</i> to VIDEO_CAPTURE_FILTER_SETTINGS_EX
+//! @date        29-Jan-15 FMB - Added MPEG-TS Pin to filter, added interface IElgatoVideoCaptureFilter6
+//!
+//! @note        The DirectShow filter works with
+//!              - Elgato Game Capture HD 
+//!              - Elgato Game Capture HD60
 //! @bc -----------------------------------------------------------------------
 //! @ec @par     Copyright
-//! @n           (c) 2012-14, Elgato Systems. All Rights Reserved.
+//! @n           (c) 2012-15, Elgato Systems. All Rights Reserved.
 //! @n
 //! @n The MIT License (MIT)
 //! @n
@@ -41,20 +45,34 @@
 /*=============================================================================
 // FILTER INTERFACE
 =============================================================================*/
-#define VIDEO_CAPTURE_FILTER_NAME            "Elgato Game Capture HD"
-#define VIDEO_CAPTURE_FILTER_NAME_L         L"Elgato Game Capture HD"
+//! Name of the filter as it appears in GraphEdt
+#define VIDEO_CAPTURE_FILTER_NAME				"Elgato Game Capture HD"
+
+//! Name of the filter as it appears in GraphEdt
+#define VIDEO_CAPTURE_FILTER_NAME_L				L"Elgato Game Capture HD"
+
+
+#define ELGATO_VCF_VIDEO_PID	100	//!< video PID in MPEG-TS stream
+#define ELGATO_VCF_AUDIO_PID	101	//!< audio PID in MPEG-TS stream
+
+
+//! Interface version:
+//! - 1st digit: interface version (e.g. 5 for IElgatoVideoCaptureFilter5)
+//! - 2nd digit: revision (changed e.g. when reserved fields in structures changed their meaning)
+#define VIDEO_CAPTURE_FILTER_INTERFACE_VERSION	60
+
 
 // {39F50F4C-99E1-464a-B6F9-D605B4FB5918}
 DEFINE_GUID(CLSID_ElgatoVideoCaptureFilter,
-0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x5, 0xb4, 0xfb, 0x59, 0x18);
+0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x05, 0xb4, 0xfb, 0x59, 0x18);
 
 // {39F50F4C-99E1-464a-B6F9-D605B4FB5919}
 DEFINE_GUID(CLSID_ElgatoVideoCaptureFilterProperties,
-0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x5, 0xb4, 0xfb, 0x59, 0x19);
+0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x05, 0xb4, 0xfb, 0x59, 0x19);
 
 // {39F50F4C-99E1-464a-B6F9-D605B4FB5920}
 DEFINE_GUID(IID_IElgatoVideoCaptureFilter,
-0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x5, 0xb4, 0xfb, 0x59, 0x20);
+0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x05, 0xb4, 0xfb, 0x59, 0x20);
 
 // {585B2914-252E-49bd-B730-7B4C40F4D4E5}
 DEFINE_GUID(IID_IElgatoVideoCaptureFilter2,
@@ -70,13 +88,19 @@ DEFINE_GUID(IID_IElgatoVideoCaptureFilter4,
 
 // {7E6E9E9E-4062-4364-99B1-15C2F662B502}
 DEFINE_GUID(IID_IElgatoVideoCaptureFilter5,
-0x7e6e9e9e, 0x4062, 0x4364, 0x99, 0xb1, 0x15, 0xc2, 0xf6, 0x62, 0xb5, 0x2);
+0x7e6e9e9e, 0x4062, 0x4364, 0x99, 0xb1, 0x15, 0xc2, 0xf6, 0x62, 0xb5, 0x02);
+
+// {39F50F4C-99E1-464a-B6F9-D605B4FB5925}
+DEFINE_GUID(IID_IElgatoVideoCaptureFilter6,
+0x39f50f4c, 0x99e1, 0x464a, 0xb6, 0xf9, 0xd6, 0x05, 0xb4, 0xfb, 0x59, 0x25);
+
+
 
 /*=============================================================================
 // IElgatoVideoCaptureFilter
 =============================================================================*/
 
-//! Interface
+//! Interface IElgatoVideoCaptureFilter
 DECLARE_INTERFACE_(IElgatoVideoCaptureFilter, IUnknown)
 {
 };
@@ -88,133 +112,151 @@ DECLARE_INTERFACE_(IElgatoVideoCaptureFilter, IUnknown)
 //! Video Capture device type
 typedef enum VIDEO_CAPTURE_FILTER_DEVICE_TYPE
 {
-    VIDEO_CAPTURE_FILTER_DEVICE_TYPE_INVALID                = 0,            //!< Invalid
-    VIDEO_CAPTURE_FILTER_DEVICE_TYPE_GAME_CAPTURE_HD        = 2,            //!< Game Capture HD   (VID: 0x0fd9 PID: 0x0044, 0x004e, 0x0051)
-    VIDEO_CAPTURE_FILTER_DEVICE_TYPE_GAME_CAPTURE_HD60      = 8,            //!< Game Capture HD60 (VID: 0x0fd9 PID: 0x005c)
-    NUM_VIDEO_CAPTURE_FILTER_DEVICE_TYPE
+	VIDEO_CAPTURE_FILTER_DEVICE_TYPE_INVALID				= 0,			//!< Invalid
+	VIDEO_CAPTURE_FILTER_DEVICE_TYPE_GAME_CAPTURE_HD		= 2,			//!< Game Capture HD   (VID: 0x0fd9 PID: 0x0044, 0x004e, 0x0051, 0x005d)
+	VIDEO_CAPTURE_FILTER_DEVICE_TYPE_GAME_CAPTURE_HD60		= 8,			//!< Game Capture HD60 (VID: 0x0fd9 PID: 0x005c)
+	NUM_VIDEO_CAPTURE_FILTER_DEVICE_TYPE
 };
 
 //! Input device
 typedef enum VIDEO_CAPTURE_FILTER_INPUT_DEVICE
 {
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_INVALID               =   0,          //!< Invalid
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_XBOX360               =   1,          //!< Microsoft Xbox 360
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_PLAYSTATION3          =   2,          //!< Sony PlayStation 3
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_IPAD                  =   3,          //!< Apple iPad
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_IPOD_IPHONE           =   4,          //!< Apple iPod or iPhone
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_WII                   =   5,          //!< Nintendo Wii
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_OTHER                 =   6,          //!< Other
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_WII_U                 =   7,          //!< Nintendo Wii U
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_XBOX_ONE              =   8,          //!< Microsoft Xbox One
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE_PLAYSTATION4          =   9,          //!< Sony PlayStation 4
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_INVALID				= 0,			//!< Invalid
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_XBOX360				= 1,			//!< Microsoft Xbox 360
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_PLAYSTATION3			= 2,			//!< Sony PlayStation 3
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_IPAD					= 3,			//!< Apple iPad
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_IPOD_IPHONE			= 4,			//!< Apple iPod or iPhone
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_WII					= 5,			//!< Nintendo Wii
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_OTHER					= 6,			//!< Other
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_WII_U					= 7,			//!< Nintendo Wii U
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_XBOX_ONE				= 8,			//!< Microsoft Xbox One
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE_PLAYSTATION4			= 9,			//!< Sony PlayStation 4
 };
 
 //! Video inputs
 typedef enum VIDEO_CAPTURE_FILTER_VIDEO_INPUT
 {
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT_INVALID                =   0,          //!< Invalid
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT_COMPOSITE              =   1,          //!< Composite
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT_SVIDEO                 =   2,          //!< S-Video
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT_COMPONENT              =   3,          //!< Component
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT_HDMI                   =   4,          //!< HDMI
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT_INVALID				= 0,			//!< Invalid
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT_COMPOSITE				= 1,			//!< Composite
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT_SVIDEO					= 2,			//!< S-Video
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT_COMPONENT				= 3,			//!< Component
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT_HDMI					= 4,			//!< HDMI
 };
 
 //! Video encoder profile
 typedef enum VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE
 {
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_INVALID            = 0x00000000,   //!< Invalid
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_240                = 0x00000001,   //!< 320x240
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_360                = 0x00000002,   //!< 480x360
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_480                = 0x00000004,   //!< 640x480
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_720                = 0x00000008,   //!< 1280x720
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_1080               = 0x00000010,   //!< 1920x1080
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_INVALID			= 0x00000000,	//!< Invalid
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_240				= 0x00000001,	//!< 320x240
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_360				= 0x00000002,	//!< 480x360
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_480				= 0x00000004,	//!< 640x480
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_720				= 0x00000008,	//!< 1280x720
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE_1080				= 0x00000010,	//!< 1920x1080
 };
 
 //! Color range
 typedef enum VIDEO_CAPTURE_FILTER_COLOR_RANGE
 {
-    VIDEO_CAPTURE_FILTER_COLOR_RANGE_INVALID                =   0,          //!< Invalid
-    VIDEO_CAPTURE_FILTER_COLOR_RANGE_FULL                   =   1,          //!< 0-255
-    VIDEO_CAPTURE_FILTER_COLOR_RANGE_LIMITED                =   2,          //!< 16-235
-    VIDEO_CAPTURE_FILTER_COLOR_RANGE_SHOOT                  =   3,          //!<
+	VIDEO_CAPTURE_FILTER_COLOR_RANGE_INVALID				= 0,			//!< Invalid
+	VIDEO_CAPTURE_FILTER_COLOR_RANGE_FULL					= 1,			//!< 0-255
+	VIDEO_CAPTURE_FILTER_COLOR_RANGE_LIMITED				= 2,			//!< 16-235
+	VIDEO_CAPTURE_FILTER_COLOR_RANGE_SHOOT					= 3,			//!<
 };
 
 //! Settings
 typedef struct _VIDEO_CAPTURE_FILTER_SETTINGS
 {
-    TCHAR                                deviceName[256];                   //!< Device name (get only)
-    VIDEO_CAPTURE_FILTER_INPUT_DEVICE    inputDevice;                       //!< Input device (e.g. Xbox360)
-    VIDEO_CAPTURE_FILTER_VIDEO_INPUT     videoInput;                        //!< Video input (e.g. HDMI)
-    VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE profile;                           //!< Video encoder profile (maximum resolution)
-    BOOL                                 useAnalogAudioInput;               //!< for HDMI with analog audio input
-    VIDEO_CAPTURE_FILTER_COLOR_RANGE     hdmiColorRange;                    //!< HDMI color range
-    int                                  brightness;                        //!< Brightness (0-10000)
-    int                                  contrast;                          //!< Contrast   (0-10000)
-    int                                  saturation;                        //!< Saturation (0-10000)
-    int                                  hue;                               //!< Hue        (0-10000)
-    int                                  analogAudioGain;                   //!< Analog audio gain  (-60 - 12 dB)
-    int                                  digitalAudioGain;                  //!< Digital audio gain (-60 - 12 dB)
-    BOOL                                 preserveInputFormat;               //!< Input Format will be preserved (e.g. do not convert interlaced to progressive)
-    BOOL                                 stretchStandardDefinitionInput;    //!< Stretch SD input to 16:9
+	TCHAR									deviceName[256];				//!< Device name (get only)
+	VIDEO_CAPTURE_FILTER_INPUT_DEVICE		inputDevice;					//!< Input device (e.g. Xbox360)
+	VIDEO_CAPTURE_FILTER_VIDEO_INPUT		videoInput;						//!< Video input (e.g. HDMI)
+	VIDEO_CAPTURE_FILTER_VID_ENC_PROFILE	profile;						//!< Video encoder profile (maximum resolution)
+	BOOL									useAnalogAudioInput;			//!< for HDMI with analog audio input
+	VIDEO_CAPTURE_FILTER_COLOR_RANGE		hdmiColorRange;					//!< HDMI color range
+	int										brightness;						//!< Brightness (0-10000)
+	int										contrast;						//!< Contrast   (0-10000)
+	int										saturation;						//!< Saturation (0-10000)
+	int										hue;							//!< Hue        (0-10000)
+	int										analogAudioGain;				//!< Analog audio gain  (-60 - 12 dB)
+	int										digitalAudioGain;				//!< Digital audio gain (-60 - 12 dB)
+	BOOL									preserveInputFormat;			//!< Input Format will be preserved (e.g. do not convert interlaced to progressive)
+	BOOL									stretchStandardDefinitionInput;	//!< Stretch SD input to 16:9
 }VIDEO_CAPTURE_FILTER_SETTINGS, *PVIDEO_CAPTURE_FILTER_SETTINGS;
 typedef const VIDEO_CAPTURE_FILTER_SETTINGS* PCVIDEO_CAPTURE_FILTER_SETTINGS;
 
-//! Interface
+//! Interface IElgatoVideoCaptureFilter2
 DECLARE_INTERFACE_(IElgatoVideoCaptureFilter2, IElgatoVideoCaptureFilter)
 {
-    // Get current settings
-    STDMETHOD(GetSettings)(THIS_ PVIDEO_CAPTURE_FILTER_SETTINGS pSettings) PURE;
+	//! Get current settings
+	STDMETHOD(GetSettings)(THIS_ PVIDEO_CAPTURE_FILTER_SETTINGS pSettings) PURE;
 
-    // Set settings
-    STDMETHOD(SetSettings)(THIS_ PCVIDEO_CAPTURE_FILTER_SETTINGS pcSettings) PURE;
+	//! Set settings
+	STDMETHOD(SetSettings)(THIS_ PCVIDEO_CAPTURE_FILTER_SETTINGS pcSettings) PURE;
 };
 
 /*=============================================================================
 // IElgatoVideoCaptureFilter3
 =============================================================================*/
 
-//! Interface
+//! Interface IElgatoVideoCaptureFilter3
 DECLARE_INTERFACE_(IElgatoVideoCaptureFilter3, IElgatoVideoCaptureFilter2)
 {
-    //! Get A/V delay in milli-seconds (approximate delay between input signal and DirectShow
-    //! filter output)
-    STDMETHOD(GetDelayMs)(THIS_ int* pnDelayMs) PURE;
+	//! Get A/V delay in milli-seconds
+	//! (approximate delay between input signal and DirectShow filter output)
+	//! @note Deprecated! use IElgatoVideoCaptureFilter3::GetDelayMs()
+	STDMETHOD(GetDelayMs_Deprecated)(THIS_ int* pnDelayMs) PURE;
 };
 
 /*=============================================================================
 // IElgatoVideoCaptureFilter4
 =============================================================================*/
 
-//! Messages
+//! Notification messages
 typedef enum VIDEO_CAPTURE_FILTER_NOTIFICATION
 {
-	//! Description: Delay of the device has changed. Call GetDelayMs() to get the new delay.
-    VIDEO_CAPTURE_FILTER_NOTIFICATION_DEVICE_DELAY_CHANGED              = 110,      //!< Data: none
+	//! Current device was removed
+	VIDEO_CAPTURE_FILTER_NOTIFICATION_DEVICE_REMOVED					= 101,		//!< Data: none
 
-	//! Description: Output format has changed. Update your signal path accordingly.
-    VIDEO_CAPTURE_FILTER_NOTIFICATION_CAPTURE_OUTPUT_FORMAT_CHANGED     = 305,      //!< Data: none
+	//! Delay of the device has changed. Call GetDelayMs() to get the new delay.
+	VIDEO_CAPTURE_FILTER_NOTIFICATION_DEVICE_DELAY_CHANGED				= 110,		//!< Data: none
+
+	//! Output format has changed. Update your signal path accordingly.
+	VIDEO_CAPTURE_FILTER_NOTIFICATION_CAPTURE_OUTPUT_FORMAT_CHANGED		= 305,		//!< Data: none
+
+	//! Video signal state has changed (e.g. present or lost)
+	VIDEO_CAPTURE_FILTER_NOTIFICATION_VIDEO_SIGNAL_STATE				= 401,		//!< Data: VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE
 };
 
-//! Custom event that can be received by IMediaEvent::GetEvent. If SetNotificationCallback() was not set this method is used to send notifications.
-//! lEventCode = VIDEO_CAPTURE_FILTER_EVENT
-//! lParam1    = VIDEO_CAPTURE_FILTER_NOTIFICATION
-//! lParam2    = reserved for future use (e.g. notifications with additional data)
+//! Video signal state
+typedef enum VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE
+{
+	VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE_PRESENT						= 0,		//!< Video present
+	VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE_LOST						= 1,		//!< No video
+	VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE_NOT_SUPPORTED				= 2,		//!< Format not supported (e.g. resolution or framerate to high)
+	VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE_DOLBY_NOT_SUPPORTED			= 3,		//!< Audio format not supported (Dolby Digital or Dolby)
+	VIDEO_CAPTURE_FILTER_VIDEO_SIGNAL_STATE_DEVICE_IN_USE				= 4			//!< Device is in use by another application
+};
+
+//! Custom event that can be received by IMediaEvent::GetEvent().
+//! @n If SetNotificationCallback() was not set this method is used to send notifications.
+//! @param lEventCode = VIDEO_CAPTURE_FILTER_EVENT
+//! @param lParam1    = VIDEO_CAPTURE_FILTER_NOTIFICATION
+//! @param lParam2    = reserved for future use (e.g. notifications with additional data)
 #define VIDEO_CAPTURE_FILTER_EVENT		EC_USER + 0x0FD9
 
 //! Message callback
 typedef void (CALLBACK* PFN_VIDEO_CAPTURE_FILTER_NOTIFICATION_CALLBACK)(VIDEO_CAPTURE_FILTER_NOTIFICATION nMessage, void* pData, int nSize, void* pContext);
 
-//! Interface
+//! Interface IElgatoVideoCaptureFilter4
 DECLARE_INTERFACE_(IElgatoVideoCaptureFilter4, IElgatoVideoCaptureFilter3)
 {
-    //! Check device is present
-    STDMETHOD(GetDevicePresent)(THIS_ BOOL* pfDevicePresent) PURE;
+	//! Check device is present
+	STDMETHOD(GetDevicePresent)(THIS_ BOOL* pfDevicePresent) PURE;
 
-    //! Get current device type
-    STDMETHOD(GetDeviceType)(THIS_ VIDEO_CAPTURE_FILTER_DEVICE_TYPE* pnDeviceType) PURE;
+	//! Get current device type
+	STDMETHOD(GetDeviceType)(THIS_ VIDEO_CAPTURE_FILTER_DEVICE_TYPE* pnDeviceType) PURE;
 
-    //! Set callback to receive notifications
-    STDMETHOD(SetNotificationCallback)(THIS_ PFN_VIDEO_CAPTURE_FILTER_NOTIFICATION_CALLBACK pCallback, void* pContext) PURE;
+	//! Set callback to receive notifications from the filter in your app.
+	STDMETHOD(SetNotificationCallback)(THIS_ PFN_VIDEO_CAPTURE_FILTER_NOTIFICATION_CALLBACK pCallback, void* pContext) PURE;
 };
 
 /*=============================================================================
@@ -225,11 +267,16 @@ DECLARE_INTERFACE_(IElgatoVideoCaptureFilter4, IElgatoVideoCaptureFilter3)
 typedef struct _VIDEO_CAPTURE_FILTER_SETTINGS_EX
 {
 	VIDEO_CAPTURE_FILTER_SETTINGS		Settings;
+
 	BOOL								enableFullFrameRate;				//!< Enable full frame rate (50/60 fps)
-	BYTE								reserved[20 * 1024];
+
+	BYTE								reserved[20 * 1024 - sizeof(DWORD)];
+
+	DWORD								interfaceVersion;					//!< Clients need to set this value to VIDEO_CAPTURE_FILTER_INTERFACE_VERSION
 }VIDEO_CAPTURE_FILTER_SETTINGS_EX, *PVIDEO_CAPTURE_FILTER_SETTINGS_EX;
 typedef const VIDEO_CAPTURE_FILTER_SETTINGS_EX* PCVIDEO_CAPTURE_FILTER_SETTINGS_EX;
 
+//! Interface IElgatoVideoCaptureFilter5
 DECLARE_INTERFACE_(IElgatoVideoCaptureFilter5, IElgatoVideoCaptureFilter4)
 {
 	//! Get current settings
@@ -238,3 +285,14 @@ DECLARE_INTERFACE_(IElgatoVideoCaptureFilter5, IElgatoVideoCaptureFilter4)
 	//! Set settings
 	STDMETHOD(SetSettingsEx)(THIS_ PCVIDEO_CAPTURE_FILTER_SETTINGS_EX pcSettings) PURE;
 };
+
+
+//! Interface IElgatoVideoCaptureFilter6
+DECLARE_INTERFACE_(IElgatoVideoCaptureFilter6, IElgatoVideoCaptureFilter5)
+{
+	//! Get A/V delay in milli-seconds
+	//! @param pnDelayMs latency of stream in milliseconds
+	//! @param forCompressedData true -> get delay for MPEG-TS pin, false -> get delay for audio/video pins
+	STDMETHOD(GetDelayMs)(THIS_ __out int* pnDelayMs, __in bool forCompressedData) PURE;
+};
+


### PR DESCRIPTION
We at Elgato found that some customers have problems with Game Capture getting out of sync.
Either Elgato Game Capture audio and video are out of sync or Elgato Game Capture A/V is getting out of sync with other sources like webcam.
We found that one import setting is to set useBuffering to make sure device timestamps are correctly used and playback is smooth (especially with the game Capture HD60)

1. These commits force a minimal buffer time of 1 msec for all Elgato devices.

2. Also the official Elgato interface header file was updated and code was changed to use information from the header file instead of duplicating information.

3. IAMStreamConfig
The upcoming version of Elgato Game Capture will properly support IAMStreamConfig on the output pins which makes some of the workarounds obsolete.
I added flags elgatoSupportsIAMStreamConfig  and elgatoCanRenderFromPin that are used to avoid the workarounds where not necessary anymore.

If needed I can provide a beta test version of Elgato Game Capture that supports IAMStreamConfig.
