### PR TITLE
Add GamingLive.tv Streaming Service

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -117,4 +117,12 @@ services : {
       "API" : https://web-api.azubu.tv/stream/broadcaster-key/
     }
   }
+  GamingLive.tv : {
+    id : 14
+    servers: {
+      "Europe"        : rtmp://broadcastEU.gaminglive.tv/push/
+      "North America" : rtmp://broadcastNA.gaminglive.tv/push/
+      "Asia"          : rtmp://broadcastAS.gaminglive.tv/push/
+    }
+  }
 }


### PR DESCRIPTION
This adds GamingLive.tv as new streaming service for OBS broadcast settings.