### PR TITLE
Update YouTube recommended keyint

### DIFF
--- a/rundir/services.xconfig
+++ b/rundir/services.xconfig
@@ -66,7 +66,7 @@ services : {
       "Backup Youtube ingest server" : rtmp://b.rtmp.youtube.com/live2?backup=1
     }
     recommended : {
-      "keyint"      : 2000
+      "keyint"      : 4000
     }
   }
   CyberGame.TV : {


### PR DESCRIPTION
The recommended keyint for YouTube live streaming is 4 seconds -
https://support.google.com/youtube/answer/2853702