### PR TITLE
Update OBS.manifest

### DIFF
--- a/OBS.manifest
+++ b/OBS.manifest
@@ -12,4 +12,12 @@
 		<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
 	</application> 
 </compatibility>
+  
+<!-- adds support for high res like 1440p at 125% size -->
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
 </assembly>


### PR DESCRIPTION
dpiAware, support for high res.

Please try it yourself with a 1440p monitor with 125% size.