### PR TITLE
Add API calls to manipulate stream key

### DIFF
--- a/OBSApi/APIInterface.h
+++ b/OBSApi/APIInterface.h
@@ -201,6 +201,15 @@ public:
     virtual void DisableTransitions() = 0;
     virtual void EnableTransitions() = 0;
     virtual bool TransitionsEnabled() const = 0;
+
+    virtual CTSTR GetStreamKey() const = 0;
+    virtual CTSTR GetStreamURL() const = 0;
+    virtual int GetStreamServiceID() const = 0;
+    virtual CTSTR GetStreamServiceFile() const = 0;
+
+    virtual void SetStreamKey(CTSTR key) = 0;
+    virtual void SetStreamURL(CTSTR url) = 0;
+    virtual void SetStreamService(int id, CTSTR file) = 0;
 };
 
 BASE_EXPORT extern APIInterface *API;
@@ -289,6 +298,15 @@ BASE_EXPORT bool OBSGetKeepRecording();
 BASE_EXPORT void OBSStartStopRecordingReplayBuffer();
 BASE_EXPORT bool OBSGetRecordingReplayBuffer();
 BASE_EXPORT void OBSSaveReplayBuffer();
+
+BASE_EXPORT CTSTR OBSGetStreamKey();
+BASE_EXPORT CTSTR OBSGetStreamURL();
+BASE_EXPORT int OBSGetStreamServiceID();
+BASE_EXPORT CTSTR OBSGetStreamServiceFile();
+
+BASE_EXPORT void OBSSetStreamKey(CTSTR key);
+BASE_EXPORT void OBSSetStreamURL(CTSTR url);
+BASE_EXPORT void OBSSetStreamService(int id, CTSTR file);
 
 BASE_EXPORT void OBSSetSourceOrder(StringList &sourceNames);
 BASE_EXPORT void OBSSetSourceRender(CTSTR lpSource, bool render);

--- a/Source/API.cpp
+++ b/Source/API.cpp
@@ -682,6 +682,18 @@ public:
     virtual void DisableTransitions()          { App->performTransition = false; }
     virtual void EnableTransitions()           { App->performTransition = true; }
     virtual bool TransitionsEnabled() const    { return App->performTransition; }
+    
+    virtual CTSTR GetStreamKey() const		   { return AppConfig->GetStringPtr(TEXT("Publish"), TEXT("PlayPath")); }
+    virtual CTSTR GetStreamURL() const		   { return AppConfig->GetStringPtr(TEXT("Publish"), TEXT("URL")); }
+    virtual int GetStreamServiceID() const	   { return AppConfig->GetInt(TEXT("Publish"), TEXT("Service")); }
+    virtual CTSTR GetStreamServiceFile() const { return AppConfig->GetStringPtr(TEXT("Publish"), TEXT("ServiceFile")); }
+
+    virtual void SetStreamKey(CTSTR key) 	   { AppConfig->SetString(TEXT("Publish"), TEXT("PlayPath"), key); }
+    virtual void SetStreamURL(CTSTR url)	   { AppConfig->SetString(TEXT("Publish"), TEXT("URL"), url); }
+    virtual void SetStreamService(int id, CTSTR file)	   { 
+        AppConfig->SetInt(TEXT("Publish"), TEXT("Service"), id);
+        AppConfig->SetString(TEXT("Publish"), TEXT("ServiceFile"), file);
+    }
 };
 
 APIInterface* CreateOBSApiInterface()


### PR DESCRIPTION
Allow plugins the ability to easily manipulate the stream key via the API.

The primary use case for these API calls would be to allow a plugin to easily provide stream key management services, however there are probably many other use cases for it as well.
