### PR TITLE
Accidental Closing Protection

### DIFF
--- a/Source/WindowStuff.cpp
+++ b/Source/WindowStuff.cpp
@@ -3593,7 +3593,25 @@ LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
                 case ID_FILE_EXIT:
                 case ID_EXIT:
-                    PostQuitMessage(0);
+                    if (App->bRunning)
+                    {
+                        if (App->bRecording)
+                        {
+                            if (OBSMessageBox(hwnd, Str("CloseRecordingWarning.Message"), Str("CloseRecordingWarning.Title"), MB_ICONQUESTION | MB_YESNO) == IDYES)
+                            {
+                                PostQuitMessage(0);
+                            }
+                        }
+                        else if (App->bStreaming)
+                        {
+                            if (OBSMessageBox(hwnd, Str("CloseStreamingWarning.Message"), Str("CloseStreamingWarning.Title"), MB_ICONQUESTION | MB_YESNO) == IDYES)
+                            {
+                                PostQuitMessage(0);
+                            }
+                        }
+                    }
+                    else
+                        PostQuitMessage(0);
                     break;
 
                 case ID_RECORDINGSFOLDER:
@@ -4503,7 +4521,25 @@ LRESULT CALLBACK OBS::OBSProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
             break;
 
         case WM_CLOSE:
-            PostQuitMessage(0);
+            if (App->bRunning)
+            {
+                if (App->bRecording)
+                {
+                    if (OBSMessageBox(hwnd, Str("CloseRecordingWarning.Message"), Str("CloseRecordingWarning.Title"), MB_ICONQUESTION | MB_YESNO) == IDYES)
+                    {
+                        PostQuitMessage(0);
+                    }
+                }
+                else if (App->bStreaming)
+                {
+                    if (OBSMessageBox(hwnd, Str("CloseStreamingWarning.Message"), Str("CloseStreamingWarning.Title"), MB_ICONQUESTION | MB_YESNO) == IDYES)
+                    {
+                        PostQuitMessage(0);
+                    }
+                }
+            }
+            else
+                PostQuitMessage(0);
             break;
 
         default:

--- a/rundir/locale/en.txt
+++ b/rundir/locale/en.txt
@@ -549,3 +549,8 @@ Plugins.NoiseGate.AttackTime="Attack time (milliseconds):"
 Plugins.NoiseGate.HoldTime="Hold time (milliseconds):"
 Plugins.NoiseGate.ReleaseTime="Release time (milliseconds):"
 
+CloseStreamingWarning.Title="OBS is currently sending a live stream."
+CloseStreamingWarning.Message="Do you want to stop the live stream and exit OBS?"
+
+CloseRecordingWarning.Title="OBS is currently recording."
+CloseRecordingWarning.Message="Do you want to stop recording and exit OBS?"


### PR DESCRIPTION
This is a small change to protect against accidentally closing OBS while the user is live or recording.

If the user clicks on Exit,File/Exit, or the X button a message Box will open asking the user if they are sure they want to close OBS while live/recording.

The message box only opens if the user is live or recording.

The message asked is "You are currently Live/Recording are you sure you want to exit OBS?" 
If you have any suggestions on what the message should be let me know.