### PR TITLE
Delay NVENC Frame output to enhance performance

### DIFF
--- a/ObsNvenc/src/NVENCEncoder.cpp
+++ b/ObsNvenc/src/NVENCEncoder.cpp
@@ -590,7 +590,7 @@ bool NVENCEncoder::Encode(LPVOID picIn, List<DataPacket> &packets, List<PacketTy
         }
     }
 
-    if (!outputSurfaceQueueReady.empty())
+    if (!outputSurfaceQueueReady.empty() && (!picIn || outputSurfaceQueue.size() + outputSurfaceQueueReady.size() >= maxSurfaceCount - 1))
     {
         NVENCEncoderOutputSurface *qSurf = outputSurfaceQueueReady.front();
         outputSurfaceQueueReady.pop();

--- a/ObsNvenc/src/NVENCEncoder.cpp
+++ b/ObsNvenc/src/NVENCEncoder.cpp
@@ -209,7 +209,7 @@ void NVENCEncoder::init()
             encoderPreset = NV_ENC_PRESET_HQ_GUID;
             is2PassRC = false;
         }
-        if (height > 720 || (height == 720 && fps > 30))
+        if (height > 720 || (height == 720 && fps > 60))
         {
             encoderPreset = NV_ENC_PRESET_LOW_LATENCY_HQ_GUID;
             is2PassRC = false;


### PR DESCRIPTION
This is causing a/v sync issues. Moving it into a seperate PR to sort it out independently.