### PR TITLE
Banned words are muted when streaming or capturing on it

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1107,7 +1107,7 @@ void OBS::ResizeWindow(bool bRedrawRenderFrame)
 
     xPos = resetXPos;
 
-    SetWindowPos(GetDlgItem(hwndMain, ID_TOGGLERECORDING), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
+    SetWindowPos(GetDlgItem(hwndMain, ID_SETTINGS), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
 
     SetWindowPos(GetDlgItem(hwndMain, ID_STARTSTOP), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
@@ -1119,22 +1119,10 @@ void OBS::ResizeWindow(bool bRedrawRenderFrame)
 
     xPos = resetXPos;
 
-    SetWindowPos(GetDlgItem(hwndMain, ID_SETTINGS), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
-    xPos += controlWidth;
-
-    SetWindowPos(GetDlgItem(hwndMain, ID_TESTSTREAM), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
-    xPos += controlWidth;
-
-    yPos += controlHeight+controlPadding;
-
-    //-----------------------------------------------------
-
-    xPos = resetXPos;
-
     SetWindowPos(GetDlgItem(hwndMain, ID_SCENEEDITOR), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
 
-    SetWindowPos(GetDlgItem(hwndMain, ID_PLUGINS), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
+    SetWindowPos(GetDlgItem(hwndMain, ID_TOGGLERECORDING), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
 
     yPos += controlHeight+controlPadding;
@@ -1146,8 +1134,17 @@ void OBS::ResizeWindow(bool bRedrawRenderFrame)
     SetWindowPos(GetDlgItem(hwndMain, ID_GLOBALSOURCES), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
     xPos += controlWidth;
 
-    /*SetWindowPos(GetDlgItem(hwndMain, ID_DASHBOARD), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
-    xPos += controlWidth;*/
+    SetWindowPos(GetDlgItem(hwndMain, ID_TESTSTREAM), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
+    xPos += controlWidth;
+
+    yPos += controlHeight+controlPadding;
+
+    //-----------------------------------------------------
+
+    xPos = resetXPos;
+
+    SetWindowPos(GetDlgItem(hwndMain, ID_PLUGINS), NULL, xPos, yPos, controlWidth-controlPadding, controlHeight, flags);
+    xPos += controlWidth;
 
     UpdateDashboardButton();
 

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1415,7 +1415,7 @@ void OBS::SetStatusBarData()
 
 void OBS::DrawStatusBar(DRAWITEMSTRUCT &dis)
 {
-    if(!App->bRunning)
+    if(!App->bRunning && !App->bStreaming && !App->bRecording)
         return;
 
     HDC hdcTemp = CreateCompatibleDC(dis.hDC);

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1386,7 +1386,9 @@ void OBS::SetStatusBarData()
 {
     if (bRunning && OSTryEnterMutex(hStartupShutdownMutex))
     {
-        if (!App->network)
+        bool bKeepRecording = GlobalConfig->GetInt(TEXT("General"), TEXT("KeepRecordingOnStopStreaming"), 1) != 0;
+
+        if (!App->network && !bKeepRecording)
             return;
 
         HWND hwndStatusBar = GetDlgItem(hwndMain, ID_STATUS);
@@ -1405,7 +1407,7 @@ void OBS::SetStatusBarData()
         {
             ReportStreamStatus(bRunning, bTestStream, 
                 (UINT) App->bytesPerSec, App->curStrain, 
-                (UINT)this->totalStreamTime, (UINT)App->network->NumTotalVideoFrames(),
+                (UINT)this->totalStreamTime, (!network) ? 0 : (UINT)App->network->NumTotalVideoFrames(),
                 (UINT)App->curFramesDropped, (UINT) App->captureFPS);
         }
 
@@ -1516,7 +1518,7 @@ void OBS::DrawStatusBar(DRAWITEMSTRUCT &dis)
                     else if(!App->bRecording && App->bStreaming && !App->bTestStream && networkMode == 0) {
                         strOutString.AppendString(TEXT(" (LIVE)"));
                     }
-                    else if(App->bRecording && App->bRunning && !App->bTestStream && networkMode == 1) {
+                    else if(App->bRecording && !App->bTestStream) {
                         strOutString.AppendString(TEXT(" (REC)"));
                     }
                     else if(App->bRunning && App->bTestStream) {

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1386,11 +1386,6 @@ void OBS::SetStatusBarData()
 {
     if (bRunning && OSTryEnterMutex(hStartupShutdownMutex))
     {
-        bool bKeepRecording = GlobalConfig->GetInt(TEXT("General"), TEXT("KeepRecordingOnStopStreaming"), 1) != 0;
-
-        if (!App->network && !bKeepRecording)
-            return;
-
         HWND hwndStatusBar = GetDlgItem(hwndMain, ID_STATUS);
 
         SendMessage(hwndStatusBar, WM_SETREDRAW, 0, 0);
@@ -1403,11 +1398,11 @@ void OBS::SetStatusBarData()
         SendMessage(hwndStatusBar, WM_SETREDRAW, 1, 0);
         InvalidateRect(hwndStatusBar, NULL, FALSE);
     
-        if(bRunning)
+        if (bRunning && network)
         {
             ReportStreamStatus(bRunning, bTestStream, 
                 (UINT) App->bytesPerSec, App->curStrain, 
-                (UINT)this->totalStreamTime, (!network) ? 0 : (UINT)App->network->NumTotalVideoFrames(),
+                (UINT)this->totalStreamTime, (UINT)network->NumTotalVideoFrames(),
                 (UINT)App->curFramesDropped, (UINT) App->captureFPS);
         }
 

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -697,9 +697,9 @@ OBS::OBS()
 
 OBS::~OBS()
 {
+    bShuttingDown = true;
     Stop();
 
-    bShuttingDown = true;
     OSTerminateThread(hHotkeyThread, 250);
 
     for(UINT i=0; i<plugins.Num(); i++)

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -650,6 +650,7 @@ OBS::OBS()
                         /* get event callbacks for the plugin */
                         pluginInfo->startStreamCallback  = (OBS_CALLBACK)GetProcAddress(hPlugin, "OnStartStream");
                         pluginInfo->stopStreamCallback   = (OBS_CALLBACK)GetProcAddress(hPlugin, "OnStopStream");
+                        pluginInfo->statusCallback        = (OBS_STATUS_CALLBACK)GetProcAddress(hPlugin, "OnOBSStatus");
                         pluginInfo->streamStatusCallback  = (OBS_STREAM_STATUS_CALLBACK)GetProcAddress(hPlugin, "OnStreamStatus");
                         pluginInfo->sceneSwitchCallback   = (OBS_SCENE_SWITCH_CALLBACK)GetProcAddress(hPlugin, "OnSceneSwitch");
                         pluginInfo->scenesChangedCallback  = (OBS_CALLBACK)GetProcAddress(hPlugin, "OnScenesChanged");
@@ -1405,6 +1406,8 @@ void OBS::SetStatusBarData()
                 (UINT)this->totalStreamTime, (UINT)network->NumTotalVideoFrames(),
                 (UINT)App->curFramesDropped, (UINT) App->captureFPS);
         }
+
+        ReportOBSStatus(bRunning, bStreaming, bRecording, bTestStream, bReconnecting);
 
         OSLeaveMutex(hStartupShutdownMutex);
     }

--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -1510,10 +1510,10 @@ void OBS::DrawStatusBar(DRAWITEMSTRUCT &dis)
                     int networkMode = AppConfig->GetInt(TEXT("Publish"), TEXT("Mode"), 2);
 
                     strOutString = FormattedString(TEXT("%u:%02u:%02u"), streamTimeHours, streamTimeMinutes, streamTimeSeconds);
-                    if(App->bRecording && App->bRunning && !App->bTestStream && networkMode == 0) {
+                    if(App->bRecording && App->bStreaming && !App->bTestStream && networkMode == 0) {
                         strOutString.AppendString(TEXT(" (LIVE + REC)"));
                     }
-                    else if(!App->bRecording && App->bRunning && !App->bTestStream && networkMode == 0) {
+                    else if(!App->bRecording && App->bStreaming && !App->bTestStream && networkMode == 0) {
                         strOutString.AppendString(TEXT(" (LIVE)"));
                     }
                     else if(App->bRecording && App->bRunning && !App->bTestStream && networkMode == 1) {

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -279,6 +279,8 @@ struct ClassInfo
 
 /* Event callback signiture definitions */
 typedef void (*OBS_CALLBACK)();
+typedef void (*OBS_STATUS_CALLBACK)(bool /*running*/, bool /*streaming*/, bool /*recording*/,
+                                    bool /*previewing*/, bool /*reconnecting*/);
 typedef void (*OBS_STREAM_STATUS_CALLBACK)(bool /*streaming*/, bool /*previewOnly*/,
                                            UINT /*bytesPerSec*/, double /*strain*/, 
                                            UINT /*totalStreamtime*/, UINT /*numTotalFrames*/, 
@@ -299,6 +301,9 @@ struct PluginInfo
     
     /* called on stream stopping */
     OBS_CALLBACK stopStreamCallback;
+
+    /* called when status bar is updated, even without network */
+    OBS_STATUS_CALLBACK statusCallback;
 
     /* called when stream stats are updated in stats window */
     OBS_STREAM_STATUS_CALLBACK streamStatusCallback;
@@ -1079,6 +1084,8 @@ public:
     // event reporting functions
     virtual void ReportStartStreamTrigger();
     virtual void ReportStopStreamTrigger();
+    virtual void OBS::ReportOBSStatus(bool running, bool streaming, bool recording,
+                                   bool previewing, bool reconnecting);
     virtual void ReportStreamStatus(bool streaming, bool previewOnly = false, 
                                    UINT bytesPerSec = 0, double strain = 0, 
                                    UINT totalStreamtime = 0, UINT numTotalFrames = 0,

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -626,7 +626,7 @@ private:
     String  strLanguage;
     bool    bTestStream;
     bool    bUseMultithreadedOptimizations;
-    bool    bRunning, bRecording, bStartingUp;
+    bool    bRunning, bRecording, bStartingUp, bStreaming;
     volatile bool bShutdownVideoThread, bShutdownEncodeThread;
     int     renderFrameWidth, renderFrameHeight; // The size of the preview only
     int     renderFrameX, renderFrameY; // The offset of the preview inside the preview control

--- a/Source/OBSCapture.cpp
+++ b/Source/OBSCapture.cpp
@@ -684,7 +684,7 @@ void OBS::Stop()
     bool bKeepRecording = GlobalConfig->GetInt(TEXT("General"), TEXT("KeepRecordingOnStopStreaming"), 1) != 0;
     int networkMode = AppConfig->GetInt(TEXT("Publish"), TEXT("Mode"), 2);
 
-    if(bRecording && bKeepRecording && networkMode == 0) {
+    if(!bShuttingDown && bRecording && bKeepRecording && networkMode == 0) {
         NetworkStream *tempStream = NULL;
         
         videoEncoder->RequestKeyframe();

--- a/Source/OBSCapture.cpp
+++ b/Source/OBSCapture.cpp
@@ -679,7 +679,7 @@ retryHookTestV2:
 
 void OBS::Stop()
 {
-    if((!bStreaming && !bRecording) && (!bTestStream)) return;
+    if((!bStreaming && !bRecording && !bRunning) && (!bTestStream)) return;
 
     bool bKeepRecording = GlobalConfig->GetInt(TEXT("General"), TEXT("KeepRecordingOnStopStreaming"), 1) != 0;
     int networkMode = AppConfig->GetInt(TEXT("Publish"), TEXT("Mode"), 2);

--- a/Source/OBSEvents.cpp
+++ b/Source/OBSEvents.cpp
@@ -46,6 +46,16 @@ void OBS::ReportStopStreamTrigger()
     }
 }
 
+void OBS::ReportOBSStatus(bool running, bool streaming, bool recording, bool previewing, bool reconnecting)
+{
+    if (bShuttingDown)
+        return;
+
+    for (UINT i = 0; i < plugins.Num(); i++)
+        if (plugins[i].statusCallback)
+            plugins[i].statusCallback(running, streaming, recording, previewing, reconnecting);
+}
+
 void OBS::ReportStreamStatus(bool streaming, bool previewOnly, 
                                UINT bytesPerSec, double strain, 
                                UINT totalStreamtime, UINT numTotalFrames,

--- a/Source/OBSVideoCapture.cpp
+++ b/Source/OBSVideoCapture.cpp
@@ -129,8 +129,10 @@ void OBS::SendFrame(VideoSegment &curSegment, QWORD firstFrameTime)
 {
     if(!bSentHeaders)
     {
-        network->BeginPublishing();
-        bSentHeaders = true;
+        if(network && curSegment.packets[0].data[0] == 0x17) {
+            network->BeginPublishing();
+            bSentHeaders = true;
+        }
     }
 
     OSEnterMutex(hSoundDataMutex);
@@ -154,7 +156,8 @@ void OBS::SendFrame(VideoSegment &curSegment, QWORD firstFrameTime)
                     {
                         //Log(TEXT("a:%u, %llu"), audioTimestamp, frameInfo.firstFrameTime+audioTimestamp);
 
-                        network->SendPacket(audioData.Array(), audioData.Num(), audioTimestamp, PacketType_Audio);
+                        if(network)
+                            network->SendPacket(audioData.Array(), audioData.Num(), audioTimestamp, PacketType_Audio);
                         if(fileStream)
                             fileStream->AddPacket(audioData.Array(), audioData.Num(), audioTimestamp, PacketType_Audio);
 
@@ -183,7 +186,8 @@ void OBS::SendFrame(VideoSegment &curSegment, QWORD firstFrameTime)
 
         //Log(TEXT("v:%u, %llu"), curSegment.timestamp, frameInfo.firstFrameTime+curSegment.timestamp);
 
-        network->SendPacket(packet.data.Array(), packet.data.Num(), curSegment.timestamp, packet.type);
+        if(network)
+            network->SendPacket(packet.data.Array(), packet.data.Num(), curSegment.timestamp, packet.type);
         if(fileStream)
             fileStream->AddPacket(packet.data.Array(), packet.data.Num(), curSegment.timestamp, packet.type);
     }
@@ -762,8 +766,12 @@ void OBS::MainCaptureLoop()
 
         //------------------------------------
 
-        QWORD curBytesSent = network->GetCurrentSentBytes();
-        curFramesDropped = network->NumDroppedFrames();
+        QWORD curBytesSent = 0;
+        
+        if(network) {
+            curBytesSent = network->GetCurrentSentBytes();
+            curFramesDropped = network->NumDroppedFrames();
+        }
 
         bpsTime += fSeconds;
         if(bpsTime > 1.0f)
@@ -796,7 +804,7 @@ void OBS::MainCaptureLoop()
 
         fpsCounter++;
 
-        curStrain = network->GetPacketStrain();
+        if(network) curStrain = network->GetPacketStrain();
 
         EnableBlending(TRUE);
         BlendFunction(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);


### PR DESCRIPTION
In the Audio setup users can mute banned words using the sound from computer.
The banned words from every language will be written in the text section.