### PR TITLE
Experimental asynchronous render / encode support

### DIFF
--- a/Source/OBS.cpp
+++ b/Source/OBS.cpp
@@ -264,6 +264,8 @@ OBS::OBS()
     hAuxAudioMutex = OSCreateMutex();
     hVideoEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
+    hVideoFrameReadyToEncode = CreateSemaphore(NULL, 0, 30, NULL);
+
     monitors.Clear();
     EnumDisplayMonitors(NULL, NULL, (MONITORENUMPROC)MonitorInfoEnumProc, (LPARAM)&monitors);
 

--- a/Source/OBS.h
+++ b/Source/OBS.h
@@ -26,6 +26,7 @@ class SettingsPane;
 struct EncoderPicture;
 
 #define NUM_RENDER_BUFFERS 2
+#define MAX_ENCODER_PICTURES 100
 
 static const int minClientWidth  = 640;
 static const int minClientHeight = 275;
@@ -878,6 +879,11 @@ private:
     QWORD firstFrameTimestamp;
     EncoderPicture * volatile curFramePic;
     HANDLE hVideoEvent;
+    HANDLE hVideoFrameReadyToEncode;
+
+    int inputIndex;
+    int encodeIndex;
+    EncoderPicture *picturesToEncode;
 
     static DWORD STDCALL EncodeThread(LPVOID lpUnused);
     static DWORD STDCALL MainCaptureThread(LPVOID lpUnused);

--- a/Source/OBSCapture.cpp
+++ b/Source/OBSCapture.cpp
@@ -974,6 +974,8 @@ void OBS::Stop(bool overrideKeepRecording, bool stopReplayBuffer)
     bShutdownEncodeThread = true;
     ShowWindow(hwndProjector, SW_HIDE);
 
+    ReleaseSemaphore(hVideoFrameReadyToEncode, 1, nullptr);
+
     if(hEncodeThread)
     {
         OSTerminateThread(hEncodeThread, 30001);


### PR DESCRIPTION
Fixes "frozen stream" effect when the encoder gets behind, greatly increases performance for slow scenes. x264 only for now. CFR, audio sync untested. Likely other bugs.